### PR TITLE
feat: 数据级权限动态化改造

### DIFF
--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/auth/AuthReactiveUserDetailsService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/auth/AuthReactiveUserDetailsService.java
@@ -11,6 +11,7 @@ import com.springddd.application.service.user.dto.SysUserRoleView;
 import com.springddd.domain.auth.AuthUser;
 import com.springddd.domain.role.ColumnRule;
 import com.springddd.domain.role.DataPermission;
+import com.springddd.domain.role.RowScope;
 import com.springddd.domain.user.UserId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
@@ -90,6 +91,9 @@ public class AuthReactiveUserDetailsService implements ReactiveUserDetailsServic
                                                     List<ColumnRule> columnRules = mergeColumnRules(roleViews);
                                                     u.setColumnRules(columnRules);
 
+                                                    DataPermission dataPermission = mergeDataPermission(roleViews);
+                                                    u.setDataPermission(dataPermission);
+
                                                     return Mono.just(u);
                                                 });
 
@@ -135,5 +139,68 @@ public class AuthReactiveUserDetailsService implements ReactiveUserDetailsServic
             result.addAll(dp.columnRules());
         }
         return result;
+    }
+
+    private DataPermission mergeDataPermission(List<SysRoleView> roleViews) {
+        if (roleViews == null || roleViews.isEmpty()) {
+            return null;
+        }
+
+        Integer strictestDataScope = 1; // default: all
+        Set<Long> mergedDeptIds = new HashSet<>();
+        Set<Long> mergedPostIds = new HashSet<>();
+        Set<Long> mergedUserIds = new HashSet<>();
+        boolean self = false;
+        List<ColumnRule> mergedColumnRules = new ArrayList<>();
+
+        for (SysRoleView roleView : roleViews) {
+            DataPermission dp = roleView.getDataPermission();
+            if (dp == null) {
+                continue;
+            }
+
+            // Merge dataScope: take the strictest (largest number)
+            Integer ds = dp.dataScope();
+            if (ds != null && ds > strictestDataScope) {
+                strictestDataScope = ds;
+            }
+
+            // Merge columnRules
+            if (dp.columnRules() != null) {
+                mergedColumnRules.addAll(dp.columnRules());
+            }
+
+            // Merge deptIds from top-level
+            if (dp.deptIds() != null) {
+                mergedDeptIds.addAll(dp.deptIds());
+            }
+
+            // Merge RowScope
+            RowScope rs = dp.rowScope();
+            if (rs != null) {
+                if (rs.deptIds() != null) {
+                    mergedDeptIds.addAll(rs.deptIds());
+                }
+                if (rs.postIds() != null) {
+                    mergedPostIds.addAll(rs.postIds());
+                }
+                if (rs.userIds() != null) {
+                    mergedUserIds.addAll(rs.userIds());
+                }
+                if (Boolean.TRUE.equals(rs.self())) {
+                    self = true;
+                }
+            }
+        }
+
+        RowScope mergedRowScope = new RowScope(
+                new ArrayList<>(mergedDeptIds),
+                new ArrayList<>(mergedPostIds),
+                new ArrayList<>(mergedUserIds),
+                self
+        );
+
+        return new DataPermission(mergedRowScope, mergedColumnRules, strictestDataScope,
+                new ArrayList<>(mergedDeptIds));
     }
 }

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/dept/SysDeptCommandService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/dept/SysDeptCommandService.java
@@ -1,6 +1,7 @@
 package com.springddd.application.service.dept;
 
 import com.springddd.application.service.dept.dto.SysDeptCommand;
+import com.springddd.application.service.permission.DataScopeCriteriaBuilder;
 import com.springddd.domain.dept.*;
 import com.springddd.infrastructure.persistence.factory.RepositoryFactory;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,8 @@ public class SysDeptCommandService {
 
     private final RestoreSysDeptByIdDomainService restoreSysDeptByIdDomainService;
 
+    private final DataScopeCriteriaBuilder dataScopeCriteriaBuilder;
+
     public Mono<Long> create(SysDeptCommand command) {
         DeptBasicInfo basicInfo = new DeptBasicInfo(command.getDeptName());
         DeptExtendInfo extendInfo = new DeptExtendInfo(command.getSortOrder(), command.getDeptStatus());
@@ -30,7 +33,8 @@ public class SysDeptCommandService {
         SysDeptDomain sysDeptDomain = sysDeptDomainFactory.newInstance(new DeptId(command.getParentId()), basicInfo, extendInfo);
         sysDeptDomain.create();
 
-        return repositoryFactory.getSysDeptDomainRepository().save(sysDeptDomain);
+        return repositoryFactory.getSysDeptDomainRepository().save(sysDeptDomain)
+                .flatMap(id -> dataScopeCriteriaBuilder.evictDeptTreeCache().thenReturn(id));
     }
 
     public Mono<Void> update(SysDeptCommand command) {
@@ -40,19 +44,22 @@ public class SysDeptCommandService {
 
             domain.update(new DeptId(command.getParentId()), basicInfo, extendInfo);
             return repositoryFactory.getSysDeptDomainRepository().save(domain);
-        }).then();
+        }).flatMap(id -> dataScopeCriteriaBuilder.evictDeptTreeCache().then());
     }
 
     public Mono<Void> delete(List<Long> ids) {
-        return deleteSysDeptByIdDomainService.deleteByIds(ids);
+        return deleteSysDeptByIdDomainService.deleteByIds(ids)
+                .then(dataScopeCriteriaBuilder.evictDeptTreeCache());
     }
 
     public Mono<Void> wipe(List<Long> ids) {
-        return wipeSysDeptByIdsDomainService.deleteByIds(ids);
+        return wipeSysDeptByIdsDomainService.deleteByIds(ids)
+                .then(dataScopeCriteriaBuilder.evictDeptTreeCache());
     }
 
     public Mono<Void> restore(List<Long> ids) {
-        return restoreSysDeptByIdDomainService.restoreByIds(ids);
+        return restoreSysDeptByIdDomainService.restoreByIds(ids)
+                .then(dataScopeCriteriaBuilder.evictDeptTreeCache());
     }
 }
 

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/dept/SysDeptQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/dept/SysDeptQueryService.java
@@ -1,12 +1,12 @@
 package com.springddd.application.service.dept;
 
+import com.springddd.application.service.permission.BaseQueryService;
 import com.springddd.application.service.dept.dto.SysDeptQuery;
 import com.springddd.application.service.dept.dto.SysDeptView;
 import com.springddd.application.service.dept.dto.SysDeptViewMapStruct;
 import com.springddd.domain.util.PageResponse;
 import com.springddd.domain.util.ReactiveTreeUtils;
 import com.springddd.infrastructure.persistence.entity.SysDeptEntity;
-import com.springddd.infrastructure.persistence.factory.QueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.Query;
@@ -18,26 +18,30 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class SysDeptQueryService {
-
-    private final QueryFactory queryFactory;
+public class SysDeptQueryService extends BaseQueryService<SysDeptEntity> {
 
     private final SysDeptViewMapStruct sysDeptViewMapStruct;
 
     public Mono<PageResponse<SysDeptView>> index(SysDeptQuery query) {
         Criteria criteria = Criteria.where(SysDeptQuery.Fields.deleteStatus).is(false);
-        Query qry = Query.query(criteria);
-        Mono<List<SysDeptView>> list = queryFactory.getR2dbcEntityTemplate().select(SysDeptEntity.class).matching(qry).all().collectList().map(sysDeptViewMapStruct::toViews);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), SysDeptEntity.class);
-        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), 0, 0));
+        return applyDataScope(criteria, SysDeptEntity.class)
+                .flatMap(scopedCriteria -> {
+                    Query qry = Query.query(scopedCriteria);
+                    Mono<List<SysDeptView>> list = queryFactory.getR2dbcEntityTemplate().select(SysDeptEntity.class).matching(qry).all().collectList().map(sysDeptViewMapStruct::toViews);
+                    Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), SysDeptEntity.class);
+                    return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), 0, 0));
+                });
     }
 
     public Mono<PageResponse<SysDeptView>> recycle(SysDeptQuery query) {
         Criteria criteria = Criteria.where(SysDeptQuery.Fields.deleteStatus).is(true);
-        Query qry = Query.query(criteria);
-        Mono<List<SysDeptView>> list = queryFactory.getR2dbcEntityTemplate().select(SysDeptEntity.class).matching(qry).all().collectList().map(sysDeptViewMapStruct::toViews);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), SysDeptEntity.class);
-        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), 0, 0));
+        return applyDataScope(criteria, SysDeptEntity.class)
+                .flatMap(scopedCriteria -> {
+                    Query qry = Query.query(scopedCriteria);
+                    Mono<List<SysDeptView>> list = queryFactory.getR2dbcEntityTemplate().select(SysDeptEntity.class).matching(qry).all().collectList().map(sysDeptViewMapStruct::toViews);
+                    Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), SysDeptEntity.class);
+                    return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), 0, 0));
+                });
     }
 
     public Mono<List<SysDeptView>> deptTree() {
@@ -58,55 +62,3 @@ public class SysDeptQueryService {
         return queryFactory.getR2dbcEntityTemplate().select(SysDeptEntity.class).all().collectList().map(sysDeptViewMapStruct::toViews);
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/dict/SysDictItemQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/dict/SysDictItemQueryService.java
@@ -1,9 +1,9 @@
 package com.springddd.application.service.dict;
 
 import com.springddd.application.service.dict.dto.*;
+import com.springddd.application.service.permission.BaseQueryService;
 import com.springddd.domain.util.PageResponse;
 import com.springddd.infrastructure.persistence.entity.SysDictItemEntity;
-import com.springddd.infrastructure.persistence.factory.QueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.Query;
@@ -15,20 +15,18 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class SysDictItemQueryService {
-
-    private final QueryFactory queryFactory;
+public class SysDictItemQueryService extends BaseQueryService<SysDictItemEntity> {
 
     private final SysDictItemViewMapStruct sysDictItemViewMapStruct;
 
     public Mono<PageResponse<SysDictItemView>> index(SysDictItemPageQuery query) {
         Criteria criteria = buildIndexCriteria(query);
-        return performQuery(query, criteria);
+        return applyDataScope(criteria, SysDictItemEntity.class).flatMap(scopedCriteria -> performQuery(query, scopedCriteria));
     }
 
     public Mono<PageResponse<SysDictItemView>> recycle(SysDictItemPageQuery query) {
         Criteria criteria = buildRecycleCriteria(query);
-        return performQuery(query, criteria);
+        return applyDataScope(criteria, SysDictItemEntity.class).flatMap(scopedCriteria -> performQuery(query, scopedCriteria));
     }
 
     private Criteria buildIndexCriteria(SysDictItemPageQuery query) {
@@ -83,62 +81,3 @@ public class SysDictItemQueryService {
         return queryFactory.getR2dbcEntityTemplate().select(SysDictItemEntity.class).matching(qry).all().collectList().map(sysDictItemViewMapStruct::toViews);
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/dict/SysDictQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/dict/SysDictQueryService.java
@@ -1,9 +1,9 @@
 package com.springddd.application.service.dict;
 
 import com.springddd.application.service.dict.dto.*;
+import com.springddd.application.service.permission.BaseQueryService;
 import com.springddd.domain.util.PageResponse;
 import com.springddd.infrastructure.persistence.entity.SysDictEntity;
-import com.springddd.infrastructure.persistence.factory.QueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.Query;
@@ -15,9 +15,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class SysDictQueryService {
-
-    private final QueryFactory queryFactory;
+public class SysDictQueryService extends BaseQueryService<SysDictEntity> {
 
     private final SysDictViewMapStruct sysDictViewMapStruct;
 
@@ -33,12 +31,14 @@ public class SysDictQueryService {
         if (!ObjectUtils.isEmpty(query.getDictCode())) {
             criteria = criteria.and(SysDictQuery.Fields.dictCode).like("%" + query.getDictCode() + "%");
         }
-        Query qry = Query.query(criteria)
-                .limit(query.getPageSize())
-                .offset((long) (query.getPageNum() - 1) * query.getPageSize());
-        Mono<List<SysDictView>> list = queryFactory.getR2dbcEntityTemplate().select(SysDictEntity.class).matching(qry).all().collectList().map(sysDictViewMapStruct::toViews);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), SysDictEntity.class);
-        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        return applyDataScope(criteria, SysDictEntity.class).flatMap(scopedCriteria -> {
+            Query qry = Query.query(scopedCriteria)
+                    .limit(query.getPageSize())
+                    .offset((long) (query.getPageNum() - 1) * query.getPageSize());
+            Mono<List<SysDictView>> list = queryFactory.getR2dbcEntityTemplate().select(SysDictEntity.class).matching(qry).all().collectList().map(sysDictViewMapStruct::toViews);
+            Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), SysDictEntity.class);
+            return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        });
     }
 
     public Mono<List<SysDictView>> queryAll() {
@@ -47,12 +47,14 @@ public class SysDictQueryService {
 
     public Mono<PageResponse<SysDictView>> recycle(SysDictPageQuery query) {
         Criteria criteria = Criteria.where(SysDictQuery.Fields.deleteStatus).is(true);
-        Query qry = Query.query(criteria)
-                .limit(query.getPageSize())
-                .offset((long) (query.getPageNum() - 1) * query.getPageSize());
-        Mono<List<SysDictView>> list = queryFactory.getR2dbcEntityTemplate().select(SysDictEntity.class).matching(qry).all().collectList().map(sysDictViewMapStruct::toViews);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), SysDictEntity.class);
-        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        return applyDataScope(criteria, SysDictEntity.class).flatMap(scopedCriteria -> {
+            Query qry = Query.query(scopedCriteria)
+                    .limit(query.getPageSize())
+                    .offset((long) (query.getPageNum() - 1) * query.getPageSize());
+            Mono<List<SysDictView>> list = queryFactory.getR2dbcEntityTemplate().select(SysDictEntity.class).matching(qry).all().collectList().map(sysDictViewMapStruct::toViews);
+            Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), SysDictEntity.class);
+            return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        });
     }
 
     public Mono<String> queryItemLabelByDictCode(String dictCode, Integer itemValue) {
@@ -89,54 +91,3 @@ public class SysDictQueryService {
                 });
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenAggregateQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenAggregateQueryService.java
@@ -5,9 +5,9 @@ import com.springddd.application.service.gen.dto.GenAggregatePageQuery;
 import com.springddd.application.service.gen.dto.GenAggregateQuery;
 import com.springddd.application.service.gen.dto.GenAggregateView;
 import com.springddd.application.service.gen.dto.GenAggregateViewMapStruct;
+import com.springddd.application.service.permission.BaseQueryService;
 import com.springddd.domain.util.PageResponse;
 import com.springddd.infrastructure.persistence.entity.GenAggregateEntity;
-import com.springddd.infrastructure.persistence.factory.QueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.Query;
@@ -19,9 +19,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class GenAggregateQueryService {
-
-    private final QueryFactory queryFactory;
+public class GenAggregateQueryService extends BaseQueryService<GenAggregateEntity> {
 
     private final GenAggregateViewMapStruct aggregateViewMapStruct;
 
@@ -30,13 +28,15 @@ public class GenAggregateQueryService {
             return Mono.empty();
         }
         Criteria criteria = Criteria.where(GenAggregateQuery.Fields.infoId).is(query.getInfoId());
-        Query qry = Query.query(criteria)
-                .limit(query.getPageSize())
-                .offset((long) (query.getPageNum() - 1) * query.getPageSize());
+        return applyDataScope(criteria, GenAggregateEntity.class).flatMap(scopedCriteria -> {
+            Query qry = Query.query(scopedCriteria)
+                    .limit(query.getPageSize())
+                    .offset((long) (query.getPageNum() - 1) * query.getPageSize());
 
-        Mono<List<GenAggregateView>> list = queryFactory.getR2dbcEntityTemplate().select(GenAggregateEntity.class).matching(qry).all().collectList().map(aggregateViewMapStruct::toViews);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), GenAggregateEntity.class);
-        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+            Mono<List<GenAggregateView>> list = queryFactory.getR2dbcEntityTemplate().select(GenAggregateEntity.class).matching(qry).all().collectList().map(aggregateViewMapStruct::toViews);
+            Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), GenAggregateEntity.class);
+            return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        });
     }
 
     public Mono<List<GenAggregateView>> queryAggregateByInfoId(Long infoId) {
@@ -44,53 +44,3 @@ public class GenAggregateQueryService {
         return queryFactory.getR2dbcEntityTemplate().select(GenAggregateEntity.class).matching(Query.query(criteria)).all().collectList().map(aggregateViewMapStruct::toViews);
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenColumnBindQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenColumnBindQueryService.java
@@ -3,9 +3,9 @@ package com.springddd.application.service.gen;
 import com.springddd.application.service.gen.dto.GenColumnBindPageQuery;
 import com.springddd.application.service.gen.dto.GenColumnBindView;
 import com.springddd.application.service.gen.dto.GenColumnBindViewMapStruct;
+import com.springddd.application.service.permission.BaseQueryService;
 import com.springddd.domain.util.PageResponse;
 import com.springddd.infrastructure.persistence.entity.GenColumnBindEntity;
-import com.springddd.infrastructure.persistence.factory.QueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.Query;
@@ -17,9 +17,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class GenColumnBindQueryService {
-
-    private final QueryFactory queryFactory;
+public class GenColumnBindQueryService extends BaseQueryService<GenColumnBindEntity> {
 
     private final GenColumnBindViewMapStruct genColumnBindViewMapStruct;
 
@@ -28,72 +26,29 @@ public class GenColumnBindQueryService {
         if (!ObjectUtils.isEmpty(query.getColumnType())) {
             criteria = criteria.and(GenColumnBindPageQuery.Fields.columnType).like("%" + query.getColumnType() + "%");
         }
-        Query qry = Query.query(criteria)
-                .limit(query.getPageSize())
-                .offset((long) (query.getPageNum() - 1) * query.getPageSize());
-        Mono<List<GenColumnBindView>> list = queryFactory.getR2dbcEntityTemplate().select(GenColumnBindEntity.class).matching(qry).all().collectList().map(genColumnBindViewMapStruct::toViews);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), GenColumnBindEntity.class);
-        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        return applyDataScope(criteria, GenColumnBindEntity.class).flatMap(scopedCriteria -> {
+            Query qry = Query.query(scopedCriteria)
+                    .limit(query.getPageSize())
+                    .offset((long) (query.getPageNum() - 1) * query.getPageSize());
+            Mono<List<GenColumnBindView>> list = queryFactory.getR2dbcEntityTemplate().select(GenColumnBindEntity.class).matching(qry).all().collectList().map(genColumnBindViewMapStruct::toViews);
+            Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), GenColumnBindEntity.class);
+            return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        });
     }
 
     public Mono<PageResponse<GenColumnBindView>> recycle(GenColumnBindPageQuery query) {
         Criteria criteria = Criteria.where(GenColumnBindPageQuery.Fields.deleteStatus).is(true);
-        Query qry = Query.query(criteria)
-                .limit(query.getPageSize())
-                .offset((long) (query.getPageNum() - 1) * query.getPageSize());
-        Mono<List<GenColumnBindView>> list = queryFactory.getR2dbcEntityTemplate().select(GenColumnBindEntity.class).matching(qry).all().collectList().map(genColumnBindViewMapStruct::toViews);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), GenColumnBindEntity.class);
-        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        return applyDataScope(criteria, GenColumnBindEntity.class).flatMap(scopedCriteria -> {
+            Query qry = Query.query(scopedCriteria)
+                    .limit(query.getPageSize())
+                    .offset((long) (query.getPageNum() - 1) * query.getPageSize());
+            Mono<List<GenColumnBindView>> list = queryFactory.getR2dbcEntityTemplate().select(GenColumnBindEntity.class).matching(qry).all().collectList().map(genColumnBindViewMapStruct::toViews);
+            Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), GenColumnBindEntity.class);
+            return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        });
     }
 
     public Mono<GenColumnBindView> queryByColumnType(String columnType) {
         return queryFactory.getR2dbcEntityTemplate().selectOne(Query.query(Criteria.where(GenColumnBindPageQuery.Fields.columnType).is(columnType)), GenColumnBindEntity.class).map(genColumnBindViewMapStruct::toView);
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenColumnsQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenColumnsQueryService.java
@@ -2,10 +2,10 @@ package com.springddd.application.service.gen;
 
 import com.springddd.application.service.dict.SysDictQueryService;
 import com.springddd.application.service.gen.dto.*;
+import com.springddd.application.service.permission.BaseQueryService;
 import com.springddd.domain.util.PageResponse;
 import com.springddd.infrastructure.persistence.entity.GenColumnsEntity;
 import com.springddd.infrastructure.persistence.entity.GenProjectInfoEntity;
-import com.springddd.infrastructure.persistence.factory.QueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.Query;
@@ -21,9 +21,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-public class GenColumnsQueryService {
-
-    private final QueryFactory queryFactory;
+public class GenColumnsQueryService extends BaseQueryService<GenColumnsEntity> {
 
     private final GenColumnsViewMapStruct genColumnsViewMapStruct;
 
@@ -157,59 +155,3 @@ public class GenColumnsQueryService {
                 );
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenProjectInfoQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenProjectInfoQueryService.java
@@ -4,10 +4,10 @@ import com.springddd.application.service.gen.dto.GenProjectInfoPageQuery;
 import com.springddd.application.service.gen.dto.GenProjectInfoQuery;
 import com.springddd.application.service.gen.dto.GenProjectInfoView;
 import com.springddd.application.service.gen.dto.GenProjectInfoViewMapStruct;
+import com.springddd.application.service.permission.BaseQueryService;
 import com.springddd.domain.gen.exception.TableNameNullException;
 import com.springddd.domain.util.PageResponse;
 import com.springddd.infrastructure.persistence.entity.GenProjectInfoEntity;
-import com.springddd.infrastructure.persistence.factory.QueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.Query;
@@ -19,9 +19,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class GenProjectInfoQueryService {
-
-    private final QueryFactory queryFactory;
+public class GenProjectInfoQueryService extends BaseQueryService<GenProjectInfoEntity> {
 
     private final GenProjectInfoViewMapStruct genProjectInfoViewMapStruct;
 
@@ -30,12 +28,14 @@ public class GenProjectInfoQueryService {
         if (!ObjectUtils.isEmpty(query.getTableName())) {
             criteria = criteria.and(GenProjectInfoPageQuery.Fields.tableName).is(query.getTableName());
         }
-        Query qry = Query.query(criteria)
-                .limit(Integer.MAX_VALUE)
-                .offset(0);
-        Mono<List<GenProjectInfoView>> list = queryFactory.getR2dbcEntityTemplate().select(GenProjectInfoEntity.class).matching(qry).all().collectList().map(genProjectInfoViewMapStruct::toViews);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), GenProjectInfoEntity.class);
-        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), 0, 0));
+        return applyDataScope(criteria, GenProjectInfoEntity.class).flatMap(scopedCriteria -> {
+            Query qry = Query.query(scopedCriteria)
+                    .limit(Integer.MAX_VALUE)
+                    .offset(0);
+            Mono<List<GenProjectInfoView>> list = queryFactory.getR2dbcEntityTemplate().select(GenProjectInfoEntity.class).matching(qry).all().collectList().map(genProjectInfoViewMapStruct::toViews);
+            Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), GenProjectInfoEntity.class);
+            return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), 0, 0));
+        });
     }
 
     public Mono<GenProjectInfoView> queryGenInfoByTableName(String tableName) {
@@ -51,62 +51,3 @@ public class GenProjectInfoQueryService {
         return queryFactory.getR2dbcEntityTemplate().select(GenProjectInfoEntity.class).matching(qry).one().map(genProjectInfoViewMapStruct::toView);
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenTemplateQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenTemplateQueryService.java
@@ -4,9 +4,9 @@ import com.springddd.application.service.gen.dto.GenTemplatePageQuery;
 import com.springddd.application.service.gen.dto.GenTemplateQuery;
 import com.springddd.application.service.gen.dto.GenTemplateView;
 import com.springddd.application.service.gen.dto.GenTemplateViewMapStruct;
+import com.springddd.application.service.permission.BaseQueryService;
 import com.springddd.domain.util.PageResponse;
 import com.springddd.infrastructure.persistence.entity.GenTemplateEntity;
-import com.springddd.infrastructure.persistence.factory.QueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.Query;
@@ -18,9 +18,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class GenTemplateQueryService {
-
-    private final QueryFactory queryFactory;
+public class GenTemplateQueryService extends BaseQueryService<GenTemplateEntity> {
 
     private final GenTemplateViewMapStruct genTemplateViewMapStruct;
 
@@ -29,82 +27,29 @@ public class GenTemplateQueryService {
         if (!ObjectUtils.isEmpty(query.getTemplateName())) {
             criteria = criteria.and(GenTemplateQuery.Fields.templateName).like("%" + query.getTemplateName() + "%");
         }
-        Query qry = Query.query(criteria)
-                .limit(query.getPageSize())
-                .offset((long) (query.getPageNum() - 1) * query.getPageSize());
-        Mono<List<GenTemplateView>> list = queryFactory.getR2dbcEntityTemplate().select(GenTemplateEntity.class).matching(qry).all().collectList().map(genTemplateViewMapStruct::toViews);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), GenTemplateEntity.class);
-        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        return applyDataScope(criteria, GenTemplateEntity.class).flatMap(scopedCriteria -> {
+            Query qry = Query.query(scopedCriteria)
+                    .limit(query.getPageSize())
+                    .offset((long) (query.getPageNum() - 1) * query.getPageSize());
+            Mono<List<GenTemplateView>> list = queryFactory.getR2dbcEntityTemplate().select(GenTemplateEntity.class).matching(qry).all().collectList().map(genTemplateViewMapStruct::toViews);
+            Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), GenTemplateEntity.class);
+            return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        });
     }
 
     public Mono<PageResponse<GenTemplateView>> recycle(GenTemplatePageQuery query) {
         Criteria criteria = Criteria.where(GenTemplateQuery.Fields.deleteStatus).is(true);
-        Query qry = Query.query(criteria)
-                .limit(query.getPageSize())
-                .offset((long) (query.getPageNum() - 1) * query.getPageSize());
-        Mono<List<GenTemplateView>> list = queryFactory.getR2dbcEntityTemplate().select(GenTemplateEntity.class).matching(qry).all().collectList().map(genTemplateViewMapStruct::toViews);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), GenTemplateEntity.class);
-        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        return applyDataScope(criteria, GenTemplateEntity.class).flatMap(scopedCriteria -> {
+            Query qry = Query.query(scopedCriteria)
+                    .limit(query.getPageSize())
+                    .offset((long) (query.getPageNum() - 1) * query.getPageSize());
+            Mono<List<GenTemplateView>> list = queryFactory.getR2dbcEntityTemplate().select(GenTemplateEntity.class).matching(qry).all().collectList().map(genTemplateViewMapStruct::toViews);
+            Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), GenTemplateEntity.class);
+            return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        });
     }
 
     public Mono<List<GenTemplateView>> queryAllTemplate() {
         return queryFactory.getR2dbcEntityTemplate().select(GenTemplateEntity.class).matching(Query.query(Criteria.where(GenTemplateQuery.Fields.deleteStatus).is(false))).all().collectList().map(genTemplateViewMapStruct::toViews);
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/SysMenuQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/SysMenuQueryService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.springddd.application.service.menu.dto.SysMenuQuery;
 import com.springddd.application.service.menu.dto.SysMenuView;
 import com.springddd.application.service.menu.dto.SysMenuViewMapStruct;
+import com.springddd.application.service.permission.BaseQueryService;
 import com.springddd.application.service.role.SysRoleQueryService;
 import com.springddd.domain.auth.AuthUser;
 import com.springddd.domain.auth.ReactiveSecurityUtils;
@@ -14,7 +15,6 @@ import com.springddd.domain.util.ReactiveTreeUtils;
 import com.springddd.infrastructure.cache.keys.CacheKeys;
 import com.springddd.infrastructure.cache.util.CacheProcessor;
 import com.springddd.infrastructure.persistence.entity.SysMenuEntity;
-import com.springddd.infrastructure.persistence.factory.QueryFactory;
 import com.springddd.infrastructure.persistence.r2dbc.SysMenuRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,11 +33,9 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class SysMenuQueryService {
+public class SysMenuQueryService extends BaseQueryService<SysMenuEntity> {
 
     private final SysMenuRepository sysMenuRepository;
-
-    private final QueryFactory queryFactory;
 
     private final SysMenuViewMapStruct sysMenuViewMapStruct;
 
@@ -49,21 +47,25 @@ public class SysMenuQueryService {
 
     public Mono<PageResponse<SysMenuView>> index(SysMenuQuery query) {
         Criteria criteria = Criteria.where(SysMenuQuery.Fields.deleteStatus).is(false);
-        Query qry = Query.query(criteria)
-                .sort(Sort.by("sort_order"));
-        Mono<List<SysMenuView>> list = queryFactory.getR2dbcEntityTemplate().select(SysMenuEntity.class).matching(qry).all().collectList()
-                .map(sysMenuViewMapStruct::toViewList);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), SysMenuEntity.class);
-        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), 0, 0));
+        return applyDataScope(criteria, SysMenuEntity.class).flatMap(scopedCriteria -> {
+            Query qry = Query.query(scopedCriteria)
+                    .sort(Sort.by("sort_order"));
+            Mono<List<SysMenuView>> list = queryFactory.getR2dbcEntityTemplate().select(SysMenuEntity.class).matching(qry).all().collectList()
+                    .map(sysMenuViewMapStruct::toViewList);
+            Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), SysMenuEntity.class);
+            return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), 0, 0));
+        });
     }
 
     public Mono<PageResponse<SysMenuView>> recycle(SysMenuQuery query) {
         Criteria criteria = Criteria.where(SysMenuQuery.Fields.deleteStatus).is(true);
-        Query qry = Query.query(criteria);
-        Mono<List<SysMenuView>> list = queryFactory.getR2dbcEntityTemplate().select(SysMenuEntity.class).matching(qry).all().collectList()
-                .map(sysMenuViewMapStruct::toViewList);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), SysMenuEntity.class);
-        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), 0, 0));
+        return applyDataScope(criteria, SysMenuEntity.class).flatMap(scopedCriteria -> {
+            Query qry = Query.query(scopedCriteria);
+            Mono<List<SysMenuView>> list = queryFactory.getR2dbcEntityTemplate().select(SysMenuEntity.class).matching(qry).all().collectList()
+                    .map(sysMenuViewMapStruct::toViewList);
+            Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), SysMenuEntity.class);
+            return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), 0, 0));
+        });
     }
 
     public Mono<SysMenuView> queryByMenuId(Long menuId) {

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/permission/BaseQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/permission/BaseQueryService.java
@@ -1,0 +1,28 @@
+package com.springddd.application.service.permission;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.relational.core.query.Criteria;
+import org.springframework.data.relational.core.query.Query;
+import org.springframework.stereotype.Component;
+import com.springddd.infrastructure.persistence.factory.QueryFactory;
+import reactor.core.publisher.Mono;
+
+public abstract class BaseQueryService<T> {
+
+    @Autowired
+    protected QueryFactory queryFactory;
+
+    @Autowired
+    protected DataScopeCriteriaBuilder dataScopeCriteriaBuilder;
+
+    protected Mono<Criteria> applyDataScope(Criteria criteria, String entityCode) {
+        return dataScopeCriteriaBuilder.apply(criteria, entityCode);
+    }
+
+    protected Mono<Criteria> applyDataScope(Criteria criteria, Class<T> entityClass) {
+        org.springframework.data.relational.core.mapping.Table tableAnnotation =
+                entityClass.getAnnotation(org.springframework.data.relational.core.mapping.Table.class);
+        String entityCode = tableAnnotation != null ? tableAnnotation.value() : entityClass.getSimpleName();
+        return applyDataScope(criteria, entityCode);
+    }
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/permission/ColumnPermissionMetadataProvider.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/permission/ColumnPermissionMetadataProvider.java
@@ -1,97 +1,18 @@
 package com.springddd.application.service.permission;
 
 import com.springddd.domain.permission.EntityColumnMetadata;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Component
+@RequiredArgsConstructor
 public class ColumnPermissionMetadataProvider {
 
+    private final EntityMetadataScanner entityMetadataScanner;
+
     public List<EntityColumnMetadata> getAllMetadata() {
-        return List.of(
-                new EntityColumnMetadata("sys_user", "用户管理", List.of(
-                        new EntityColumnMetadata.ColumnInfo("id", "ID"),
-                        new EntityColumnMetadata.ColumnInfo("username", "用户名"),
-                        new EntityColumnMetadata.ColumnInfo("password", "密码"),
-                        new EntityColumnMetadata.ColumnInfo("phone", "手机号"),
-                        new EntityColumnMetadata.ColumnInfo("avatar", "头像"),
-                        new EntityColumnMetadata.ColumnInfo("email", "邮箱"),
-                        new EntityColumnMetadata.ColumnInfo("sex", "性别"),
-                        new EntityColumnMetadata.ColumnInfo("lockStatus", "锁定状态"),
-                        new EntityColumnMetadata.ColumnInfo("deptId", "部门ID"),
-                        new EntityColumnMetadata.ColumnInfo("createBy", "创建人"),
-                        new EntityColumnMetadata.ColumnInfo("updateBy", "更新人"),
-                        new EntityColumnMetadata.ColumnInfo("createTime", "创建时间"),
-                        new EntityColumnMetadata.ColumnInfo("updateTime", "更新时间")
-                )),
-                new EntityColumnMetadata("sys_dept", "部门管理", List.of(
-                        new EntityColumnMetadata.ColumnInfo("id", "ID"),
-                        new EntityColumnMetadata.ColumnInfo("parentId", "上级部门"),
-                        new EntityColumnMetadata.ColumnInfo("deptName", "部门名称"),
-                        new EntityColumnMetadata.ColumnInfo("leader", "联系人"),
-                        new EntityColumnMetadata.ColumnInfo("phone", "电话"),
-                        new EntityColumnMetadata.ColumnInfo("sortOrder", "排序"),
-                        new EntityColumnMetadata.ColumnInfo("deptStatus", "状态"),
-                        new EntityColumnMetadata.ColumnInfo("createBy", "创建人"),
-                        new EntityColumnMetadata.ColumnInfo("updateBy", "更新人"),
-                        new EntityColumnMetadata.ColumnInfo("createTime", "创建时间"),
-                        new EntityColumnMetadata.ColumnInfo("updateTime", "更新时间")
-                )),
-                new EntityColumnMetadata("sys_role", "角色管理", List.of(
-                        new EntityColumnMetadata.ColumnInfo("id", "ID"),
-                        new EntityColumnMetadata.ColumnInfo("roleName", "角色名称"),
-                        new EntityColumnMetadata.ColumnInfo("roleCode", "角色编码"),
-                        new EntityColumnMetadata.ColumnInfo("roleDesc", "角色描述"),
-                        new EntityColumnMetadata.ColumnInfo("dataScope", "数据范围"),
-                        new EntityColumnMetadata.ColumnInfo("dataPermission", "数据权限"),
-                        new EntityColumnMetadata.ColumnInfo("roleStatus", "状态"),
-                        new EntityColumnMetadata.ColumnInfo("ownerStatus", "负责人状态"),
-                        new EntityColumnMetadata.ColumnInfo("deptId", "部门ID"),
-                        new EntityColumnMetadata.ColumnInfo("createBy", "创建人"),
-                        new EntityColumnMetadata.ColumnInfo("updateBy", "更新人"),
-                        new EntityColumnMetadata.ColumnInfo("createTime", "创建时间"),
-                        new EntityColumnMetadata.ColumnInfo("updateTime", "更新时间")
-                )),
-                new EntityColumnMetadata("sys_dict", "字典管理", List.of(
-                        new EntityColumnMetadata.ColumnInfo("id", "ID"),
-                        new EntityColumnMetadata.ColumnInfo("dictName", "字典名称"),
-                        new EntityColumnMetadata.ColumnInfo("dictCode", "字典编码"),
-                        new EntityColumnMetadata.ColumnInfo("dictDesc", "字典描述"),
-                        new EntityColumnMetadata.ColumnInfo("dictStatus", "状态"),
-                        new EntityColumnMetadata.ColumnInfo("createBy", "创建人"),
-                        new EntityColumnMetadata.ColumnInfo("updateBy", "更新人"),
-                        new EntityColumnMetadata.ColumnInfo("createTime", "创建时间"),
-                        new EntityColumnMetadata.ColumnInfo("updateTime", "更新时间")
-                )),
-                new EntityColumnMetadata("sys_dict_item", "字典项管理", List.of(
-                        new EntityColumnMetadata.ColumnInfo("id", "ID"),
-                        new EntityColumnMetadata.ColumnInfo("dictId", "字典ID"),
-                        new EntityColumnMetadata.ColumnInfo("itemLabel", "标签"),
-                        new EntityColumnMetadata.ColumnInfo("itemValue", "值"),
-                        new EntityColumnMetadata.ColumnInfo("sortOrder", "排序"),
-                        new EntityColumnMetadata.ColumnInfo("itemStatus", "状态"),
-                        new EntityColumnMetadata.ColumnInfo("createBy", "创建人"),
-                        new EntityColumnMetadata.ColumnInfo("updateBy", "更新人"),
-                        new EntityColumnMetadata.ColumnInfo("createTime", "创建时间"),
-                        new EntityColumnMetadata.ColumnInfo("updateTime", "更新时间")
-                )),
-                new EntityColumnMetadata("sys_menu", "菜单管理", List.of(
-                        new EntityColumnMetadata.ColumnInfo("id", "ID"),
-                        new EntityColumnMetadata.ColumnInfo("parentId", "上级菜单"),
-                        new EntityColumnMetadata.ColumnInfo("menuName", "菜单名称"),
-                        new EntityColumnMetadata.ColumnInfo("menuType", "菜单类型"),
-                        new EntityColumnMetadata.ColumnInfo("path", "路径"),
-                        new EntityColumnMetadata.ColumnInfo("component", "组件"),
-                        new EntityColumnMetadata.ColumnInfo("permission", "权限标识"),
-                        new EntityColumnMetadata.ColumnInfo("icon", "图标"),
-                        new EntityColumnMetadata.ColumnInfo("sortOrder", "排序"),
-                        new EntityColumnMetadata.ColumnInfo("menuStatus", "状态"),
-                        new EntityColumnMetadata.ColumnInfo("createBy", "创建人"),
-                        new EntityColumnMetadata.ColumnInfo("updateBy", "更新人"),
-                        new EntityColumnMetadata.ColumnInfo("createTime", "创建时间"),
-                        new EntityColumnMetadata.ColumnInfo("updateTime", "更新时间")
-                ))
-        );
+        return entityMetadataScanner.getAllMetadata();
     }
 }

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/permission/DataScopeCriteriaBuilder.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/permission/DataScopeCriteriaBuilder.java
@@ -1,0 +1,193 @@
+package com.springddd.application.service.permission;
+
+import com.springddd.application.service.dept.SysDeptQueryService;
+import com.springddd.application.service.dept.dto.SysDeptView;
+import com.springddd.domain.auth.AuthUser;
+import com.springddd.domain.auth.ReactiveSecurityUtils;
+import com.springddd.domain.permission.DataScopeEnabled;
+import com.springddd.domain.role.DataPermission;
+import com.springddd.domain.role.RowScope;
+import com.springddd.infrastructure.cache.keys.CacheKeys;
+import com.springddd.infrastructure.cache.util.CacheDefinition;
+import com.springddd.infrastructure.cache.util.CacheProcessor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.relational.core.query.Criteria;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.ObjectUtils;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DataScopeCriteriaBuilder {
+
+    private final SysDeptQueryService sysDeptQueryService;
+    private final EntityMetadataScanner entityMetadataScanner;
+    private final CacheProcessor cacheProcessor;
+
+    private static final CacheDefinition DEPT_TREE_CACHE = CacheDefinition.of("datascope:dept:tree", Duration.ofMinutes(5));
+    private static final String DEPT_ID_FIELD = "deptId";
+    private static final String CREATE_BY_FIELD = "createBy";
+    private static final String ID_FIELD = "id";
+
+    public Mono<Criteria> apply(Criteria criteria, String entityCode) {
+        if (criteria == null) {
+            criteria = Criteria.empty();
+        }
+        if (ObjectUtils.isEmpty(entityCode)) {
+            return Mono.just(criteria);
+        }
+
+        final Criteria baseCriteria = criteria;
+        return ReactiveSecurityUtils.getCurrentUser()
+                .flatMap(user -> applyInternal(baseCriteria, entityCode, user))
+                .switchIfEmpty(Mono.just(baseCriteria));
+    }
+
+    private Mono<Criteria> applyInternal(Criteria criteria, String entityCode, AuthUser user) {
+        // Super admin bypass
+        if (isSuperAdmin(user)) {
+            return Mono.just(criteria);
+        }
+
+        DataPermission dataPermission = user.getDataPermission();
+        if (dataPermission == null || dataPermission.dataScope() == null) {
+            return Mono.just(criteria);
+        }
+
+        Integer dataScope = dataPermission.dataScope();
+
+        return switch (dataScope) {
+            case 1 -> Mono.just(criteria); // All data
+            case 2 -> applyDeptScope(criteria, entityCode, user.getDeptId(), false);
+            case 3 -> applyDeptScope(criteria, entityCode, user.getDeptId(), true);
+            case 4 -> applySelfScope(criteria, entityCode, user.getUsername());
+            case 5 -> applyCustomScope(criteria, entityCode, dataPermission.rowScope(), user);
+            default -> Mono.just(criteria);
+        };
+    }
+
+    private boolean isSuperAdmin(AuthUser user) {
+        return user != null && "admin".equals(user.getUsername());
+    }
+
+    private Mono<Criteria> applyDeptScope(Criteria criteria, String entityCode, Long deptId, boolean includeSubDepts) {
+        if (deptId == null) {
+            return Mono.just(criteria);
+        }
+
+        // Check if entity has deptId field
+        if (!entityMetadataScanner.hasField(entityCode, DEPT_ID_FIELD)) {
+            log.debug("Entity {} does not have deptId field, skipping dept scope", entityCode);
+            return Mono.just(criteria);
+        }
+
+        if (!includeSubDepts) {
+            return Mono.just(criteria.and(DEPT_ID_FIELD).is(deptId));
+        }
+
+        // Include sub-departments
+        return getAllChildDeptIds(deptId)
+                .map(deptIds -> criteria.and(DEPT_ID_FIELD).in(deptIds));
+    }
+
+    private Mono<Criteria> applySelfScope(Criteria criteria, String entityCode, String username) {
+        if (ObjectUtils.isEmpty(username)) {
+            return Mono.just(criteria);
+        }
+
+        // Prefer createBy filter; if entity doesn't have createBy, fall back to id matching (less ideal)
+        if (entityMetadataScanner.hasField(entityCode, CREATE_BY_FIELD)) {
+            return Mono.just(criteria.and(CREATE_BY_FIELD).is(username));
+        }
+
+        log.debug("Entity {} does not have createBy field, cannot apply self scope", entityCode);
+        return Mono.just(criteria);
+    }
+
+    private Mono<Criteria> applyCustomScope(Criteria criteria, String entityCode, RowScope rowScope, AuthUser user) {
+        if (rowScope == null) {
+            return Mono.just(criteria);
+        }
+
+        boolean hasCondition = false;
+        Criteria result = criteria;
+
+        // deptIds condition
+        if (!CollectionUtils.isEmpty(rowScope.deptIds())
+                && entityMetadataScanner.hasField(entityCode, DEPT_ID_FIELD)) {
+            result = result.and(DEPT_ID_FIELD).in(rowScope.deptIds());
+            hasCondition = true;
+        }
+
+        // self condition
+        if (Boolean.TRUE.equals(rowScope.self())
+                && entityMetadataScanner.hasField(entityCode, CREATE_BY_FIELD)
+                && !ObjectUtils.isEmpty(user.getUsername())) {
+            result = result.and(CREATE_BY_FIELD).is(user.getUsername());
+            hasCondition = true;
+        }
+
+        // userIds condition - map userIds to usernames, then filter by createBy
+        if (!CollectionUtils.isEmpty(rowScope.userIds())
+                && entityMetadataScanner.hasField(entityCode, CREATE_BY_FIELD)) {
+            // For simplicity, we filter by id if the entity has id field and userIds match ids
+            // Otherwise we need a user lookup which is complex in reactive context
+            // Fallback: if self is also set, we already covered current user
+            // If not, we can't easily map userIds to usernames here without extra DB call
+            log.debug("Custom scope userIds not fully supported without username lookup for entity {}", entityCode);
+        }
+
+        if (!hasCondition) {
+            return Mono.just(criteria);
+        }
+        return Mono.just(result);
+    }
+
+    private Mono<Set<Long>> getAllChildDeptIds(Long rootDeptId) {
+        String cacheKey = DEPT_TREE_CACHE.buildKey(rootDeptId);
+
+        return cacheProcessor.getCache(cacheKey, List.class)
+                .flatMap(cached -> {
+                    try {
+                        @SuppressWarnings("unchecked")
+                        List<Long> ids = (List<Long>) cached;
+                        return Mono.just(new HashSet<>(ids));
+                    } catch (Exception e) {
+                        return loadAndCacheChildDeptIds(rootDeptId, cacheKey);
+                    }
+                })
+                .switchIfEmpty(loadAndCacheChildDeptIds(rootDeptId, cacheKey));
+    }
+
+    private Mono<Set<Long>> loadAndCacheChildDeptIds(Long rootDeptId, String cacheKey) {
+        return sysDeptQueryService.queryAllDept()
+                .map(allDepts -> {
+                    Set<Long> result = new HashSet<>();
+                    result.add(rootDeptId);
+                    collectChildDeptIds(allDepts, rootDeptId, result);
+                    return result;
+                })
+                .flatMap(ids -> cacheProcessor.setCache(cacheKey, new ArrayList<>(ids), DEPT_TREE_CACHE.ttl())
+                        .thenReturn(ids));
+    }
+
+    private void collectChildDeptIds(List<SysDeptView> allDepts, Long parentId, Set<Long> result) {
+        for (SysDeptView dept : allDepts) {
+            if (parentId.equals(dept.getParentId())) {
+                result.add(dept.getId());
+                collectChildDeptIds(allDepts, dept.getId(), result);
+            }
+        }
+    }
+
+    public Mono<Void> evictDeptTreeCache() {
+        return cacheProcessor.deleteCache(DEPT_TREE_CACHE.buildKey("*"));
+    }
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/permission/DefaultEntityPathResolver.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/permission/DefaultEntityPathResolver.java
@@ -1,0 +1,75 @@
+package com.springddd.application.service.permission;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class DefaultEntityPathResolver implements EntityPathResolver {
+
+    private final Map<String, String> pathMappings = new ConcurrentHashMap<>();
+
+    @Value("#{${spring.ddd.permission.path-mapping:{}}}")
+    private Map<String, String> explicitMappings = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        // Register explicit mappings from configuration
+        if (explicitMappings != null) {
+            pathMappings.putAll(explicitMappings);
+        }
+        log.info("Registered {} explicit path mappings", pathMappings.size());
+    }
+
+    @Override
+    public Optional<String> resolveEntityCode(String path) {
+        if (path == null || path.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // 1. Check explicit mappings first
+        for (Map.Entry<String, String> entry : pathMappings.entrySet()) {
+            if (path.startsWith(entry.getKey())) {
+                return Optional.of(entry.getValue());
+            }
+        }
+
+        // 2. Convention-based derivation
+        String entityCode = deriveByConvention(path);
+        if (entityCode != null && !entityCode.isEmpty()) {
+            return Optional.of(entityCode);
+        }
+
+        return Optional.empty();
+    }
+
+    private String deriveByConvention(String path) {
+        // Remove leading slash and convert path segments to snake_case
+        String normalized = path.startsWith("/") ? path.substring(1) : path;
+        
+        // Split by /
+        String[] segments = normalized.split("/");
+        if (segments.length == 0) {
+            return null;
+        }
+
+        // Build entity code: e.g., "sys/user" -> "sys_user", "gen/aggregate" -> "gen_aggregate"
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < segments.length; i++) {
+            if (i > 0) {
+                sb.append("_");
+            }
+            sb.append(segments[i]);
+        }
+
+        return sb.toString();
+    }
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/permission/EntityMetadataScanner.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/permission/EntityMetadataScanner.java
@@ -1,0 +1,102 @@
+package com.springddd.application.service.permission;
+
+import com.springddd.domain.permission.DataPermissionEntity;
+import com.springddd.domain.permission.EntityColumnMetadata;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class EntityMetadataScanner {
+
+    private static final String BASE_PACKAGE = "com.springddd.infrastructure.persistence.entity";
+
+    private final Map<String, EntityColumnMetadata> metadataCache = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    public void init() {
+        scanEntities();
+    }
+
+    private void scanEntities() {
+        ClassPathScanningCandidateComponentProvider scanner =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AnnotationTypeFilter(Table.class));
+
+        Set<BeanDefinition> candidates = scanner.findCandidateComponents(BASE_PACKAGE);
+
+        for (BeanDefinition candidate : candidates) {
+            try {
+                Class<?> clazz = Class.forName(candidate.getBeanClassName());
+                Table tableAnnotation = clazz.getAnnotation(Table.class);
+                DataPermissionEntity dpAnnotation = clazz.getAnnotation(DataPermissionEntity.class);
+
+                String entityCode = tableAnnotation.value();
+                String entityName = (dpAnnotation != null && !dpAnnotation.name().isEmpty())
+                        ? dpAnnotation.name()
+                        : entityCode;
+
+                List<EntityColumnMetadata.ColumnInfo> columns = extractColumns(clazz);
+                EntityColumnMetadata metadata = new EntityColumnMetadata(entityCode, entityName, columns);
+                metadataCache.put(entityCode, metadata);
+            } catch (ClassNotFoundException e) {
+                log.warn("Failed to load entity class: {}", candidate.getBeanClassName(), e);
+            }
+        }
+
+        log.info("Scanned {} data-permission entities", metadataCache.size());
+    }
+
+    private List<EntityColumnMetadata.ColumnInfo> extractColumns(Class<?> clazz) {
+        List<EntityColumnMetadata.ColumnInfo> columns = new ArrayList<>();
+        Set<String> fieldNames = new LinkedHashSet<>();
+
+        // Collect all declared fields including inherited ones
+        Class<?> current = clazz;
+        while (current != null && current != Object.class) {
+            for (Field field : current.getDeclaredFields()) {
+                // Skip Spring Data internal fields and static fields
+                if (java.lang.reflect.Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
+                String name = field.getName();
+                if ("serialVersionUID".equals(name)) {
+                    continue;
+                }
+                if (fieldNames.add(name)) {
+                    columns.add(new EntityColumnMetadata.ColumnInfo(name, name));
+                }
+            }
+            current = current.getSuperclass();
+        }
+
+        return columns;
+    }
+
+    public List<EntityColumnMetadata> getAllMetadata() {
+        return new ArrayList<>(metadataCache.values());
+    }
+
+    public Optional<EntityColumnMetadata> getMetadata(String entityCode) {
+        return Optional.ofNullable(metadataCache.get(entityCode));
+    }
+
+    public boolean hasEntity(String entityCode) {
+        return metadataCache.containsKey(entityCode);
+    }
+
+    public boolean hasField(String entityCode, String fieldName) {
+        return metadataCache.get(entityCode) != null
+                && metadataCache.get(entityCode).columns().stream()
+                        .anyMatch(c -> c.field().equals(fieldName));
+    }
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/permission/EntityPathResolver.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/permission/EntityPathResolver.java
@@ -1,0 +1,8 @@
+package com.springddd.application.service.permission;
+
+import java.util.Optional;
+
+public interface EntityPathResolver {
+
+    Optional<String> resolveEntityCode(String path);
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/role/SysRoleQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/role/SysRoleQueryService.java
@@ -1,13 +1,13 @@
 package com.springddd.application.service.role;
 
 
+import com.springddd.application.service.permission.BaseQueryService;
 import com.springddd.application.service.role.dto.SysRolePageQuery;
 import com.springddd.application.service.role.dto.SysRoleQuery;
 import com.springddd.application.service.role.dto.SysRoleView;
 import com.springddd.application.service.role.dto.SysRoleViewMapStruct;
 import com.springddd.domain.util.PageResponse;
 import com.springddd.infrastructure.persistence.entity.SysRoleEntity;
-import com.springddd.infrastructure.persistence.factory.QueryFactory;
 import com.springddd.infrastructure.persistence.r2dbc.SysRoleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.relational.core.query.Criteria;
@@ -20,9 +20,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class SysRoleQueryService {
-
-    private final QueryFactory queryFactory;
+public class SysRoleQueryService extends BaseQueryService<SysRoleEntity> {
 
     private final SysRoleViewMapStruct sysRoleViewMapStruct;
 
@@ -36,26 +34,32 @@ public class SysRoleQueryService {
         if (!ObjectUtils.isEmpty(query.getRoleCode())) {
             criteria = criteria.and(SysRoleQuery.Fields.roleCode).like("%" + query.getRoleCode() + "%");
         }
-        Query qry = Query.query(criteria)
-                .limit(query.getPageSize())
-                .offset((long) (query.getPageNum() - 1) * query.getPageSize());
+        return applyDataScope(criteria, SysRoleEntity.class)
+                .flatMap(scopedCriteria -> {
+                    Query qry = Query.query(scopedCriteria)
+                            .limit(query.getPageSize())
+                            .offset((long) (query.getPageNum() - 1) * query.getPageSize());
 
-        Mono<List<SysRoleView>> list = queryFactory.getR2dbcEntityTemplate().select(SysRoleEntity.class).matching(qry).all().collectList().map(sysRoleViewMapStruct::toViewList);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), SysRoleEntity.class);
-        return Mono.zip(list, count)
-                .map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+                    Mono<List<SysRoleView>> list = queryFactory.getR2dbcEntityTemplate().select(SysRoleEntity.class).matching(qry).all().collectList().map(sysRoleViewMapStruct::toViewList);
+                    Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), SysRoleEntity.class);
+                    return Mono.zip(list, count)
+                            .map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+                });
     }
 
     public Mono<PageResponse<SysRoleView>> recycle(SysRolePageQuery query) {
         Criteria criteria = Criteria.where(SysRoleQuery.Fields.deleteStatus).is(true);
-        Query qry = Query.query(criteria)
-                .limit(query.getPageSize())
-                .offset((long) (query.getPageNum() - 1) * query.getPageSize());
+        return applyDataScope(criteria, SysRoleEntity.class)
+                .flatMap(scopedCriteria -> {
+                    Query qry = Query.query(scopedCriteria)
+                            .limit(query.getPageSize())
+                            .offset((long) (query.getPageNum() - 1) * query.getPageSize());
 
-        Mono<List<SysRoleView>> list = queryFactory.getR2dbcEntityTemplate().select(SysRoleEntity.class).matching(qry).all().collectList().map(sysRoleViewMapStruct::toViewList);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), SysRoleEntity.class);
-        return Mono.zip(list, count)
-                .map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+                    Mono<List<SysRoleView>> list = queryFactory.getR2dbcEntityTemplate().select(SysRoleEntity.class).matching(qry).all().collectList().map(sysRoleViewMapStruct::toViewList);
+                    Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), SysRoleEntity.class);
+                    return Mono.zip(list, count)
+                            .map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+                });
     }
 
     public Mono<SysRoleView> getById(Long id) {
@@ -73,66 +77,3 @@ public class SysRoleQueryService {
         return sysRoleRepository.findAll().collectList().map(sysRoleViewMapStruct::toViewList);
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/user/SysUserQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/user/SysUserQueryService.java
@@ -1,12 +1,12 @@
 package com.springddd.application.service.user;
 
+import com.springddd.application.service.permission.BaseQueryService;
 import com.springddd.application.service.user.dto.SysUserPageQuery;
 import com.springddd.application.service.user.dto.SysUserQuery;
 import com.springddd.application.service.user.dto.SysUserView;
 import com.springddd.application.service.user.dto.SysUserViewMapStruct;
 import com.springddd.domain.util.PageResponse;
 import com.springddd.infrastructure.persistence.entity.SysUserEntity;
-import com.springddd.infrastructure.persistence.factory.QueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.Query;
@@ -18,9 +18,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class SysUserQueryService {
-
-    private final QueryFactory queryFactory;
+public class SysUserQueryService extends BaseQueryService<SysUserEntity> {
 
     private final SysUserViewMapStruct sysUserViewMapStruct;
 
@@ -32,87 +30,37 @@ public class SysUserQueryService {
         if (!ObjectUtils.isEmpty(query.getPhone())) {
             criteria = criteria.and(SysUserQuery.Fields.phone).like("%" + query.getPhone() + "%");
         }
-        Query qry = Query.query(criteria)
-                .limit(query.getPageSize())
-                .offset((long) (query.getPageNum() - 1) * query.getPageSize());
+        return applyDataScope(criteria, SysUserEntity.class)
+                .flatMap(scopedCriteria -> {
+                    Query qry = Query.query(scopedCriteria)
+                            .limit(query.getPageSize())
+                            .offset((long) (query.getPageNum() - 1) * query.getPageSize());
 
-        Mono<List<SysUserView>> list = queryFactory.getR2dbcEntityTemplate().select(SysUserEntity.class).matching(qry).all().collectList().map(sysUserViewMapStruct::toViewList);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), SysUserEntity.class);
-        return Mono.zip(list, count)
-                .map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
-
+                    Mono<List<SysUserView>> list = queryFactory.getR2dbcEntityTemplate().select(SysUserEntity.class).matching(qry).all().collectList().map(sysUserViewMapStruct::toViewList);
+                    Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), SysUserEntity.class);
+                    return Mono.zip(list, count)
+                            .map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+                });
     }
 
     public Mono<PageResponse<SysUserView>> recycle(SysUserPageQuery query) {
         Criteria criteria = Criteria.where(SysUserPageQuery.Fields.deleteStatus).is(true);
-        Query qry = Query.query(criteria)
-                .limit(query.getPageSize())
-                .offset((long) (query.getPageNum() - 1) * query.getPageSize());
-        Mono<List<SysUserView>> list = queryFactory.getR2dbcEntityTemplate().select(SysUserEntity.class).matching(qry).all().collectList().map(sysUserViewMapStruct::toViewList);
-        Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(criteria), SysUserEntity.class);
-        return Mono.zip(list, count)
-                .map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+        return applyDataScope(criteria, SysUserEntity.class)
+                .flatMap(scopedCriteria -> {
+                    Query qry = Query.query(scopedCriteria)
+                            .limit(query.getPageSize())
+                            .offset((long) (query.getPageNum() - 1) * query.getPageSize());
+                    Mono<List<SysUserView>> list = queryFactory.getR2dbcEntityTemplate().select(SysUserEntity.class).matching(qry).all().collectList().map(sysUserViewMapStruct::toViewList);
+                    Mono<Long> count = queryFactory.getR2dbcEntityTemplate().count(Query.query(scopedCriteria), SysUserEntity.class);
+                    return Mono.zip(list, count)
+                            .map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+                });
     }
 
     public Mono<SysUserView> queryUserByUsername(String username) {
         return queryFactory.getR2dbcEntityTemplate().selectOne(Query.query(
-                Criteria.where(SysUserQuery.Fields.username)
-                        .is(username).and(SysUserQuery.Fields.deleteStatus).is(false)), SysUserEntity.class)
+                        Criteria.where(SysUserQuery.Fields.username)
+                                .is(username).and(SysUserQuery.Fields.deleteStatus).is(false)), SysUserEntity.class)
                 .map(sysUserViewMapStruct::toView);
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/auth/AuthUser.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/auth/AuthUser.java
@@ -2,6 +2,7 @@ package com.springddd.domain.auth;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.springddd.domain.role.ColumnRule;
+import com.springddd.domain.role.DataPermission;
 import com.springddd.domain.user.UserId;
 import lombok.Data;
 import org.springframework.security.core.GrantedAuthority;
@@ -54,6 +55,11 @@ public class AuthUser implements Serializable, UserDetails {
      * 原始列权限规则列表（支持多维度匹配）
      */
     private List<ColumnRule> columnRules = new ArrayList<>();
+
+    /**
+     * 数据权限（行级+列级合并后）
+     */
+    private DataPermission dataPermission;
 
     @JsonIgnore
     @Override

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/permission/DataPermissionEntity.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/permission/DataPermissionEntity.java
@@ -1,0 +1,13 @@
+package com.springddd.domain.permission;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DataPermissionEntity {
+
+    String entityCode() default "";
+
+    String name() default "";
+}

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/permission/DataScopeEnabled.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/permission/DataScopeEnabled.java
@@ -1,0 +1,11 @@
+package com.springddd.domain.permission;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DataScopeEnabled {
+
+    String entityCode() default "";
+}

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/GenAggregateEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/GenAggregateEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import com.springddd.domain.util.LeafId;
 import lombok.Data;
 import org.springframework.data.annotation.*;
@@ -9,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Table("gen_aggregate")
+@DataPermissionEntity(name = "聚合根管理")
 public class GenAggregateEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/GenColumnBindEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/GenColumnBindEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import com.springddd.domain.util.LeafId;
 import lombok.Data;
 import org.springframework.data.annotation.*;
@@ -9,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Table("gen_column_bind")
+@DataPermissionEntity(name = "列绑定管理")
 public class GenColumnBindEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/GenColumnsEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/GenColumnsEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import com.springddd.domain.util.LeafId;
 import lombok.Data;
 import org.springframework.data.annotation.*;
@@ -9,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Table("gen_columns")
+@DataPermissionEntity(name = "列管理")
 public class GenColumnsEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/GenProjectInfoEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/GenProjectInfoEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import com.springddd.domain.util.LeafId;
 import lombok.Data;
 import org.springframework.data.annotation.*;
@@ -9,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Table("gen_project_info")
+@DataPermissionEntity(name = "项目信息管理")
 public class GenProjectInfoEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/GenTableInfoEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/GenTableInfoEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import lombok.Data;
 
 import java.time.LocalDateTime;

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/GenTemplateEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/GenTemplateEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import com.springddd.domain.util.LeafId;
 import lombok.Data;
 import org.springframework.data.annotation.*;
@@ -9,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Table("gen_template")
+@DataPermissionEntity(name = "模板管理")
 public class GenTemplateEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/LeafAllocEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/LeafAllocEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
@@ -8,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Table("leaf_alloc")
+@DataPermissionEntity(name = "号段分配")
 public class LeafAllocEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/LeafWorkerEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/LeafWorkerEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
@@ -8,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Table("leaf_worker")
+@DataPermissionEntity(name = "Worker节点")
 public class LeafWorkerEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysDeptEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysDeptEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import com.springddd.domain.util.LeafId;
 import lombok.Data;
 import org.springframework.data.annotation.*;
@@ -9,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Table("sys_dept")
+@DataPermissionEntity(name = "部门管理")
 public class SysDeptEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysDictEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysDictEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import com.springddd.domain.util.LeafId;
 import lombok.Data;
 import org.springframework.data.annotation.*;
@@ -9,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Table("sys_dict")
+@DataPermissionEntity(name = "字典管理")
 public class SysDictEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysDictItemEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysDictItemEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import com.springddd.domain.util.LeafId;
 import lombok.Data;
 import org.springframework.data.annotation.*;
@@ -9,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Table("sys_dict_item")
+@DataPermissionEntity(name = "字典项管理")
 public class SysDictItemEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysMenuEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysMenuEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import com.springddd.domain.util.LeafId;
 import lombok.Data;
 import org.springframework.data.annotation.*;
@@ -9,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Table("sys_menu")
+@DataPermissionEntity(name = "菜单管理")
 public class SysMenuEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysRoleEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysRoleEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import com.springddd.domain.util.LeafId;
 import lombok.Data;
 import org.springframework.data.annotation.*;
@@ -14,6 +16,7 @@ import java.time.LocalDateTime;
  */
 @Data
 @Table("sys_role")
+@DataPermissionEntity(name = "角色管理")
 public class SysRoleEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysRoleMenuEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysRoleMenuEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import com.springddd.domain.util.LeafId;
 import lombok.Data;
 import org.springframework.data.annotation.*;
@@ -9,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Table("sys_role_menu")
+@DataPermissionEntity(name = "角色菜单关联")
 public class SysRoleMenuEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysUserEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysUserEntity.java
@@ -1,5 +1,6 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
 import com.springddd.domain.util.LeafId;
 import lombok.Data;
 import org.springframework.data.annotation.*;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
  */
 @Data
 @Table("sys_user")
+@DataPermissionEntity(name = "用户管理")
 public class SysUserEntity {
 
     @Id

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysUserRoleEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysUserRoleEntity.java
@@ -1,5 +1,7 @@
 package com.springddd.infrastructure.persistence.entity;
 
+import com.springddd.domain.permission.DataPermissionEntity;
+
 import com.springddd.domain.util.LeafId;
 import lombok.Data;
 import org.springframework.data.annotation.*;
@@ -9,6 +11,7 @@ import java.time.LocalDateTime;
 
 @Data
 @Table("sys_user_role")
+@DataPermissionEntity(name = "用户角色关联")
 public class SysUserRoleEntity {
 
     @Id

--- a/spring-ddd-interface-web/src/main/java/com/springddd/web/filter/ColumnPermissionResponseFilter.java
+++ b/spring-ddd-interface-web/src/main/java/com/springddd/web/filter/ColumnPermissionResponseFilter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.springddd.application.service.permission.EntityPathResolver;
 import com.springddd.domain.auth.ReactiveSecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +24,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import java.util.Set;
 
 @Slf4j
@@ -33,21 +33,7 @@ import java.util.Set;
 public class ColumnPermissionResponseFilter implements WebFilter {
 
     private final ObjectMapper objectMapper;
-
-    private static final Map<String, String> PATH_TO_ENTITY_MAP = Map.ofEntries(
-            Map.entry("/sys/user", "sys_user"),
-            Map.entry("/sys/dept", "sys_dept"),
-            Map.entry("/sys/role", "sys_role"),
-            Map.entry("/sys/dict/item", "sys_dict_item"),
-            Map.entry("/sys/dict", "sys_dict"),
-            Map.entry("/sys/menu", "sys_menu"),
-            Map.entry("/gen/aggregate", "gen_aggregate"),
-            Map.entry("/gen/column/bind", "gen_column_bind"),
-            Map.entry("/gen/columns", "gen_columns"),
-            Map.entry("/gen/projectInfo", "gen_project_info"),
-            Map.entry("/gen/table", "gen_table"),
-            Map.entry("/gen/template", "gen_template")
-    );
+    private final EntityPathResolver entityPathResolver;
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
@@ -94,12 +80,7 @@ public class ColumnPermissionResponseFilter implements WebFilter {
     }
 
     private String resolveEntityCode(String path) {
-        for (Map.Entry<String, String> entry : PATH_TO_ENTITY_MAP.entrySet()) {
-            if (path.startsWith(entry.getKey())) {
-                return entry.getValue();
-            }
-        }
-        return null;
+        return entityPathResolver.resolveEntityCode(path).orElse(null);
     }
 
     private Mono<String> filterResponse(String json, String entityCode) {


### PR DESCRIPTION
- 列权限元数据：反射扫描 @Table 实体，替换硬编码
- URL→Entity 映射：基于约定推导，替换硬编码
- 行级权限：支持 dataScope 1-5，改造 11 个 Query Service
- AuthUser 增加 dataPermission，多角色合并取最严格
- 部门树缓存 + 增删改自动清除