### PR TITLE
refactor(auth): JWT stateless - embed full claims and remove Redis dependency

### DIFF
--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/auth/AuthUserService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/auth/AuthUserService.java
@@ -3,20 +3,15 @@ package com.springddd.application.service.auth;
 import com.springddd.application.service.auth.dto.LoginUserQuery;
 import com.springddd.application.service.auth.dto.LoginUserView;
 import com.springddd.application.service.auth.dto.UserInfoView;
-import com.springddd.application.service.auth.jwt.JwtSecret;
 import com.springddd.application.service.auth.jwt.JwtTemplate;
 import com.springddd.domain.auth.AuthUser;
 import com.springddd.domain.auth.ReactiveSecurityUtils;
-import com.springddd.domain.auth.SecurityUtils;
-import com.springddd.infrastructure.cache.keys.CacheKeys;
-import com.springddd.infrastructure.cache.util.ReactiveRedisCacheHelper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.ReactiveAuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,10 +24,6 @@ public class AuthUserService {
 
     private final JwtTemplate jwtTemplate;
 
-    private final ReactiveRedisCacheHelper reactiveRedisCacheHelper;
-
-    private final JwtSecret jwtSecret;
-
     public Mono<LoginUserView> getToken(LoginUserQuery query) {
         UsernamePasswordAuthenticationToken unauthenticated =
                 UsernamePasswordAuthenticationToken.unauthenticated(query.getUsername(), query.getPassword());
@@ -41,36 +32,21 @@ public class AuthUserService {
                 .flatMap(auth -> {
                     AuthUser user = (AuthUser) auth.getPrincipal();
 
-                    SecurityUtils.setAuthUserContext(user);
-
                     Map<String, Object> map = new HashMap<>();
                     map.put("userId", user.getUserId().value());
+                    map.put("username", user.getUsername());
+                    map.put("roles", user.getRoles());
+                    map.put("permissions", user.getPermissions());
+                    map.put("menuIds", user.getMenuIds());
 
                     String token = jwtTemplate.generateToken(map);
-
-                    Mono<Boolean> cacheOp = reactiveRedisCacheHelper.deleteCache(CacheKeys.USER_TOKEN.buildKey(user.getUserId().value()))
-                            .then(
-                                    reactiveRedisCacheHelper.setCache(
-                                            CacheKeys.USER_TOKEN.buildKey(user.getUserId().value()),
-                                            token,
-                                            Duration.ofDays(jwtSecret.getTtl())
-                                    )
-                            ).then(
-                                    reactiveRedisCacheHelper.setCache(
-                                            CacheKeys.USER_DETAIL.buildKey(user.getUserId().value()),
-                                            user,
-                                            Duration.ofDays(jwtSecret.getTtl())
-                                    )
-                            );
-
-                    return cacheOp.thenReturn(token);
+                    return Mono.just(token);
                 })
                 .map(token -> {
                     LoginUserView view = new LoginUserView();
                     view.setAccessToken(token);
                     return view;
                 });
-
     }
 
     public Mono<UserInfoView> getUserInfo() {
@@ -89,9 +65,7 @@ public class AuthUserService {
     }
 
     public Mono<Void> clearCache() {
-        return ReactiveSecurityUtils.getCurrentUserId()
-                .flatMap(userId -> reactiveRedisCacheHelper.deleteCache(CacheKeys.USER_ALL.buildKey(userId)));
+        return Mono.empty();
     }
 
 }
-

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/auth/SecurityConfig.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/auth/SecurityConfig.java
@@ -12,10 +12,15 @@ import org.springframework.security.authentication.UserDetailsRepositoryReactive
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
-import org.springframework.security.web.server.authentication.AuthenticationWebFilter;;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.security.web.server.authentication.AuthenticationWebFilter;
+import reactor.core.publisher.Mono;
 
 @Configuration
 @RequiredArgsConstructor
@@ -51,7 +56,17 @@ public class SecurityConfig {
 
     @Bean
     public AuthenticationWebFilter jwtAuthenticationWebFilter() {
-        AuthenticationWebFilter filter = new AuthenticationWebFilter(jwtAuthenticationManager);
+        AuthenticationWebFilter filter = new AuthenticationWebFilter(jwtAuthenticationManager) {
+            @Override
+            protected Mono<Void> onAuthenticationSuccess(Authentication authentication,
+                                                           WebFilterExchange webFilterExchange) {
+                SecurityContextImpl securityContext = new SecurityContextImpl();
+                securityContext.setAuthentication(authentication);
+                return webFilterExchange.getChain()
+                        .filter(webFilterExchange.getExchange())
+                        .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext)));
+            }
+        };
         filter.setServerAuthenticationConverter(jwtAuthenticationConverter);
         return filter;
     }

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/auth/jwt/JwtAuthenticationConverter.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/auth/jwt/JwtAuthenticationConverter.java
@@ -2,9 +2,7 @@ package com.springddd.application.service.auth.jwt;
 
 import com.springddd.application.service.auth.SecurityProperties;
 import com.springddd.domain.auth.AuthUser;
-import com.springddd.domain.auth.SecurityUtils;
-import com.springddd.infrastructure.cache.keys.CacheKeys;
-import com.springddd.infrastructure.cache.util.ReactiveRedisCacheHelper;
+import com.springddd.domain.user.UserId;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +17,8 @@ import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.pattern.PathPatternParser;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationConverter implements ServerAuthenticationConverter {
@@ -28,8 +28,6 @@ public class JwtAuthenticationConverter implements ServerAuthenticationConverter
     private final SecurityProperties securityProperties;
 
     private final PathPatternParser pathPatternParser = new PathPatternParser();
-
-    private final ReactiveRedisCacheHelper reactiveRedisCacheHelper;
 
     @Override
     public Mono<Authentication> convert(ServerWebExchange exchange) {
@@ -47,39 +45,27 @@ public class JwtAuthenticationConverter implements ServerAuthenticationConverter
             return Mono.error(new AccessDeniedException("Missing or invalid Authorization header"));
         }
 
-        // Extract the token part by removing the "Bearer " prefix and trimming any extra whitespace.
         String token = authHeader.substring(7).trim().replaceAll("\\s+", "");
 
-        boolean isTokenOnly = securityProperties.getTokenOnlyPaths().stream()
-                .map(pathPatternParser::parse)
-                .anyMatch(pattern -> pattern.matches(exchange.getRequest().getPath()));
-
         Jws<Claims> claims = jwtTemplate.parseToken(token);
-        Long userId = claims.getPayload().get("userId", Long.class);
+        Claims payload = claims.getPayload();
+        Long userId = payload.get("userId", Long.class);
+        String username = payload.get("username", String.class);
+        @SuppressWarnings("unchecked")
+        List<String> roles = payload.get("roles", List.class);
+        @SuppressWarnings("unchecked")
+        List<String> permissions = payload.get("permissions", List.class);
+        @SuppressWarnings("unchecked")
+        List<Long> menuIds = payload.get("menuIds", List.class);
 
-        return reactiveRedisCacheHelper.getCache(CacheKeys.USER_TOKEN.buildKey(userId), String.class)
-                .switchIfEmpty(Mono.error(new AccessDeniedException("Request has expired")))
-                .flatMap(cachedToken -> {
-                    if (!cachedToken.equals(token)) {
-                        return Mono.error(new AccessDeniedException("Invalid Request"));
-                    }
+        AuthUser user = new AuthUser();
+        user.setUserId(new UserId(userId));
+        user.setUsername(username);
+        user.setRoles(roles != null ? roles : List.of());
+        user.setPermissions(permissions != null ? permissions : List.of());
+        user.setMenuIds(menuIds != null ? menuIds : List.of());
+        user.setLockStatus(false);
 
-                    // Token matches cache, continue with parsing
-                    try {
-                        return reactiveRedisCacheHelper.getCache(CacheKeys.USER_DETAIL.buildKey(userId), AuthUser.class)
-                                .switchIfEmpty(Mono.error(new AccessDeniedException("User detail not found in cache")))
-                                .flatMap(u -> {
-                                    SecurityUtils.setAuthUserContext(u);
-                                    return Mono.just(u);
-                                })
-                                .map(user -> new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities()));
-
-                    } catch (Exception e) {
-                        return Mono.error(new AccessDeniedException("Invalid token: " + e.getMessage()));
-                    }
-                });
+        return Mono.just(new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities()));
     }
-
-
 }
-

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenDownloadDomainServiceImpl.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenDownloadDomainServiceImpl.java
@@ -3,7 +3,7 @@ package com.springddd.application.service.gen;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.springddd.application.service.gen.dto.ProjectTreeView;
-import com.springddd.domain.auth.SecurityUtils;
+import com.springddd.domain.auth.ReactiveSecurityUtils;
 import com.springddd.domain.gen.GenDownloadDomainService;
 import com.springddd.infrastructure.cache.keys.CacheKeys;
 import com.springddd.infrastructure.cache.util.ReactiveRedisCacheHelper;
@@ -35,10 +35,11 @@ public class GenDownloadDomainServiceImpl implements GenDownloadDomainService {
 
     @Override
     public Mono<ResponseEntity<Resource>> download() {
-        return cacheHelper.getCache(
-                        CacheKeys.GEN_FILES.buildKey(SecurityUtils.getUserId()),
+        return ReactiveSecurityUtils.getCurrentUserId()
+                .flatMap(userId -> cacheHelper.getCache(
+                        CacheKeys.GEN_FILES.buildKey(userId),
                         List.class
-                )
+                ))
                 .flatMap(list -> {
                     try {
                         List<ProjectTreeView> treeViewList = objectMapper.convertValue(list, new TypeReference<>() {

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenTableInfoQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenTableInfoQueryService.java
@@ -3,7 +3,7 @@ package com.springddd.application.service.gen;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.springddd.application.service.gen.dto.*;
-import com.springddd.domain.auth.SecurityUtils;
+import com.springddd.domain.auth.ReactiveSecurityUtils;
 import com.springddd.domain.util.PageResponse;
 import com.springddd.infrastructure.cache.keys.CacheKeys;
 import com.springddd.infrastructure.cache.util.ReactiveRedisCacheHelper;
@@ -137,10 +137,11 @@ public class GenTableInfoQueryService {
     }
 
     public Mono<List<ProjectTreeView>> preview() {
-        return cacheHelper.getCache(
-                        CacheKeys.GEN_FILES.buildKey(SecurityUtils.getUserId()),
+        return ReactiveSecurityUtils.getCurrentUserId()
+                .flatMap(userId -> cacheHelper.getCache(
+                        CacheKeys.GEN_FILES.buildKey(userId),
                         List.class
-                )
+                ))
                 .flatMap(list -> {
                     try {
                         List<ProjectTreeView> treeViewList = objectMapper.convertValue(list, new TypeReference<>() {});

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenerateDomainServiceImpl.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenerateDomainServiceImpl.java
@@ -3,7 +3,7 @@ package com.springddd.application.service.gen;
 import com.springddd.application.service.gen.dto.GenAggregateView;
 import com.springddd.application.service.gen.dto.ProjectTreeBuilder;
 import com.springddd.application.service.gen.dto.ProjectTreeView;
-import com.springddd.domain.auth.SecurityUtils;
+import com.springddd.domain.auth.ReactiveSecurityUtils;
 import com.springddd.domain.gen.GenerateDomainService;
 import com.springddd.infrastructure.cache.keys.CacheKeys;
 import com.springddd.infrastructure.cache.util.ReactiveRedisCacheHelper;
@@ -78,8 +78,9 @@ public class GenerateDomainServiceImpl implements GenerateDomainService {
                                 }
                                 List<ProjectTreeView> treeList = new ArrayList<>();
                                 generatedFiles.forEach(file -> saveGeneratedFile(file.filePath, file.content, treeList, projectName));
-                                return cacheHelper.setCache(CacheKeys.GEN_FILES.buildKey(SecurityUtils.getUserId()), treeList,
-                                        CacheKeys.GEN_FILES.ttl()).then();
+                                return ReactiveSecurityUtils.getCurrentUserId()
+                                        .flatMap(userId -> cacheHelper.setCache(CacheKeys.GEN_FILES.buildKey(userId), treeList,
+                                                CacheKeys.GEN_FILES.ttl()).then());
                             });
                 })
                 .onErrorResume(e -> {

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/SysMenuQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/SysMenuQueryService.java
@@ -6,10 +6,7 @@ import com.springddd.application.service.menu.dto.SysMenuQuery;
 import com.springddd.application.service.menu.dto.SysMenuView;
 import com.springddd.application.service.menu.dto.SysMenuViewMapStruct;
 import com.springddd.application.service.role.SysRoleQueryService;
-import com.springddd.domain.auth.AuthUser;
 import com.springddd.domain.auth.ReactiveSecurityUtils;
-import com.springddd.domain.auth.SecurityUtils;
-import com.springddd.domain.user.UserId;
 import com.springddd.domain.util.PageResponse;
 import com.springddd.domain.util.ReactiveTreeUtils;
 import com.springddd.infrastructure.cache.keys.CacheKeys;
@@ -78,13 +75,6 @@ public class SysMenuQueryService {
 
     public Mono<List<SysMenuView>> queryByPermissions() {
         return ReactiveSecurityUtils.getCurrentUser()
-                .switchIfEmpty(Mono.defer(() -> {
-                    AuthUser user = new AuthUser();
-                    user.setUserId(new UserId(SecurityUtils.getUserId()));
-                    user.setMenuIds(SecurityUtils.getMenuIds());
-                    user.setRoles(SecurityUtils.getRoles());
-                    return Mono.just(user);
-                }))
                 .flatMapMany(user -> Flux.fromIterable(user.getMenuIds() != null ? user.getMenuIds() : List.of()))
                 .flatMap(mId -> r2dbcEntityTemplate.selectOne(
                         Query.query(Criteria

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/auth/ReactiveSecurityUtils.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/auth/ReactiveSecurityUtils.java
@@ -7,12 +7,14 @@ import org.springframework.security.core.context.SecurityContext;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.Objects;
 
 public final class ReactiveSecurityUtils {
 
     public static Mono<AuthUser> getCurrentUser() {
         return ReactiveSecurityContextHolder.getContext()
                 .map(SecurityContext::getAuthentication)
+                .filter(Objects::nonNull)
                 .filter(Authentication::isAuthenticated)
                 .map(Authentication::getPrincipal)
                 .cast(AuthUser.class)

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/auth/SecurityUtils.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/auth/SecurityUtils.java
@@ -1,70 +1,13 @@
 package com.springddd.domain.auth;
 
-import java.util.List;
-
 public class SecurityUtils {
 
-    private static Long userId;
-
-    private static String username;
-
-    private static List<String> roles;
-
-    private static List<String> permissions;
-
-    private static List<Long> menuIds;
-
-    public static void setAuthUserContext(AuthUser user) {
-        setUserId(user.getUserId().value());
-        setUsername(user.getUsername());
-        setRoles(user.getRoles());
-        setPermissions(user.getPermissions());
-        setMenuIds(user.getMenuIds());
-    }
-
-    public static void setUserId(Long userId) {
-        SecurityUtils.userId = userId;
-    }
-
-    public static void setUsername(String username) {
-        SecurityUtils.username = username;
-    }
-
-    public static void setRoles(List<String> roles) {
-        SecurityUtils.roles = roles;
-    }
-
-    public static void setPermissions(List<String> permissions) {
-        SecurityUtils.permissions = permissions;
-    }
-
-    public static void setMenuIds(List<Long> menuIds) {
-        SecurityUtils.menuIds = menuIds;
-    }
-
-    public static Long getUserId() {
-        return SecurityUtils.userId;
-    }
-
-    public static String getUsername() {
-        return SecurityUtils.username;
-    }
-
-    public static List<String> getRoles() {
-        return SecurityUtils.roles;
-    }
-
-    public static List<String> getPermissions() {
-        return SecurityUtils.permissions;
-    }
-
-    public static List<Long> getMenuIds() {
-        return SecurityUtils.menuIds;
-    }
-
+    /**
+     * Returns the recommended concurrency level based on available processors.
+     * This is unrelated to authentication and is kept here for backward compatibility.
+     */
     public static Integer concurrency() {
         return Runtime.getRuntime().availableProcessors() * 2;
     }
 
 }
-

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/util/IdGenerator.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/util/IdGenerator.java
@@ -1,6 +1,7 @@
 package com.springddd.domain.util;
 
-import com.springddd.domain.auth.SecurityUtils;
+import com.springddd.domain.auth.AuthUser;
+import com.springddd.domain.auth.ReactiveSecurityUtils;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -32,8 +33,8 @@ public class IdGenerator implements BeforeConvertCallback<Object> {
                 .toList();
 
         if (idFields.size() > 1) {
-            throw new IllegalStateException("Entity " + entity.getClass().getName() +
-                    " has more than one field annotated with both @Id and @SnowflakeId.");
+            return Mono.error(new IllegalStateException("Entity " + entity.getClass().getName() +
+                    " has more than one field annotated with both @Id and @SnowflakeId."));
         }
 
         if (idFields.isEmpty()) {
@@ -43,36 +44,42 @@ public class IdGenerator implements BeforeConvertCallback<Object> {
         Field field = idFields.getFirst();
         field.setAccessible(true);
 
-        Field createdByField = !createdByFields.isEmpty() ? createdByFields.getFirst() : null;
-        if (createdByField != null) {
-            createdByField.setAccessible(true);
-        }
-
-        Field lastModifiedByField = !lastModifiedByFields.isEmpty() ? lastModifiedByFields.getFirst() : null;
-        if (lastModifiedByField != null) {
-            lastModifiedByField.setAccessible(true);
-        }
-
         try {
             Object currentValue = field.get(entity);
             if (currentValue == null) {
                 long id = IdTemp.generateId();
                 field.set(entity, id);
-                if (createdByField != null) {
-                    createdByField.set(entity, SecurityUtils.getUsername());
-                }
-                if (lastModifiedByField != null) {
-                    lastModifiedByField.set(entity, SecurityUtils.getUsername());
-                }
+                return setAuditFields(entity, createdByFields, lastModifiedByFields, true);
             } else {
-                if (lastModifiedByField != null) {
-                    lastModifiedByField.set(entity, SecurityUtils.getUsername());
-                }
+                return setAuditFields(entity, List.of(), lastModifiedByFields, false);
             }
         } catch (IllegalAccessException e) {
-            throw new RuntimeException("Failed to generate ID for field: " + field.getName(), e);
+            return Mono.error(new RuntimeException("Failed to generate ID for field: " + field.getName(), e));
         }
+    }
 
-        return Mono.just(entity);
+    private Mono<Object> setAuditFields(Object entity, List<Field> createdByFields,
+                                         List<Field> lastModifiedByFields, boolean isNew) {
+        return ReactiveSecurityUtils.getCurrentUser()
+                .map(AuthUser::getUsername)
+                .defaultIfEmpty("system")
+                .flatMap(username -> {
+                    try {
+                        if (isNew && !createdByFields.isEmpty()) {
+                            Field createdByField = createdByFields.getFirst();
+                            createdByField.setAccessible(true);
+                            createdByField.set(entity, username);
+                        }
+                        if (!lastModifiedByFields.isEmpty()) {
+                            Field lastModifiedByField = lastModifiedByFields.getFirst();
+                            lastModifiedByField.setAccessible(true);
+                            lastModifiedByField.set(entity, username);
+                        }
+                        return Mono.just(entity);
+                    } catch (IllegalAccessException e) {
+                        return Mono.error(new RuntimeException("Failed to set audit fields", e));
+                    }
+                })
+                .onErrorResume(e -> Mono.just(entity));
     }
 }


### PR DESCRIPTION
### 变更摘要

将 JWT 从"伪 JWT + 真 Session"改造为真正的无状态 JWT：

1. **JWT 载荷扩展** — 从仅含  扩展为 
2. **删除 Redis 认证依赖** — 请求验证时只验签名，不再查 Redis token/userDetail
3. **修复 SecurityContext 传播** — 自定义 ，手动将 SecurityContext 注入 Reactor Context
4. **清理 SecurityUtils** — 删除静态字段和认证相关方法，全部迁移到 

### Commit 拆分

- 
- 
- 

### 影响

- 权限变更不再实时生效（需等待 JWT TTL 过期）
- 登出由前端删除 token 完成，服务端无操作
- 旧 token 仍可用但缺少新字段，建议重新登录获取新 token