### PR TITLE
fix(template): commandService skips server-managed fields

### DIFF
--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/DeleteLeafWorkerDomainServiceImpl.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/DeleteLeafWorkerDomainServiceImpl.java
@@ -1,0 +1,28 @@
+package com.springddd.application.service.leaf;
+
+import com.springddd.domain.auth.ReactiveSecurityUtils;
+import com.springddd.domain.leaf.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DeleteLeafWorkerDomainServiceImpl implements DeleteLeafWorkerDomainService {
+
+    private final LeafWorkerDomainRepository domainRepository;
+    
+    @Override
+    public Mono<Void> deleteByIds(List<Long> ids) {
+        return Flux.fromIterable(ids)
+                .flatMap(id -> domainRepository.load(new LeafId(id))
+                        .flatMap(domain -> {
+                            domain.delete();
+                            return domainRepository.save(domain);
+                        }), ReactiveSecurityUtils.concurrency())
+                .then();
+    }
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/LeafWorkerCommandService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/LeafWorkerCommandService.java
@@ -1,0 +1,58 @@
+package com.springddd.application.service.leaf;
+
+import com.springddd.application.service.leaf.dto.LeafWorkerCommand;
+import com.springddd.domain.leaf.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LeafWorkerCommandService {
+
+    private final LeafWorkerDomainRepository leafWorkerDomainRepository;
+
+    private final LeafWorkerDomainFactory leafWorkerDomainFactory;
+
+    private final DeleteLeafWorkerDomainService deleteLeafWorkerDomainService;
+    
+    private final RestoreLeafWorkerDomainService restoreLeafWorkerDomainService;
+
+    private final WipeLeafWorkerDomainService wipeLeafWorkerDomainService;
+
+    public Mono<Long> create(LeafWorkerCommand command) {
+        Worker worker = new Worker(command.getWorkerId(), command.getDatacenterId());
+        Address address = new Address(command.getIp(), command.getPort());
+        ExtendInfo extendInfo = new ExtendInfo(command.getLastTimestamp(), null, command.getDeleteStatus());
+
+        LeafWorkerDomain domain = leafWorkerDomainFactory.newInstance(worker, address, extendInfo);
+        domain.create();
+        return leafWorkerDomainRepository.save(domain);
+    }
+
+    public Mono<Void> update(LeafWorkerCommand command) {
+        Worker worker = new Worker(command.getWorkerId(), command.getDatacenterId());
+        Address address = new Address(command.getIp(), command.getPort());
+        ExtendInfo extendInfo = new ExtendInfo(command.getLastTimestamp(), null, command.getDeleteStatus());
+
+        return leafWorkerDomainRepository.load(new LeafId(command.getId()))
+                .flatMap(domain -> {
+                    domain.update(worker, address, extendInfo);
+                    return leafWorkerDomainRepository.save(domain);
+                }).then();
+    }
+
+    public Mono<Void> delete(List<Long> ids) {
+        return deleteLeafWorkerDomainService.deleteByIds(ids);
+    }
+    
+    public Mono<Void> restore(List<Long> ids) {
+        return restoreLeafWorkerDomainService.restoreByIds(ids);
+    }
+
+    public Mono<Void> wipe(List<Long> ids) {
+        return wipeLeafWorkerDomainService.wipeByIds(ids);
+    }
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/LeafWorkerDomainFactoryImpl.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/LeafWorkerDomainFactoryImpl.java
@@ -1,0 +1,17 @@
+package com.springddd.application.service.leaf;
+
+import com.springddd.domain.leaf.*;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LeafWorkerDomainFactoryImpl implements LeafWorkerDomainFactory {
+
+    @Override
+    public LeafWorkerDomain newInstance(Worker worker, Address address, ExtendInfo extendInfo) {
+        LeafWorkerDomain domain = new LeafWorkerDomain();
+        domain.setWorker(worker);
+        domain.setAddress(address);
+        domain.setExtendInfo(extendInfo);
+        return domain;
+    }
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/LeafWorkerQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/LeafWorkerQueryService.java
@@ -1,0 +1,72 @@
+package com.springddd.application.service.leaf;
+
+import com.springddd.application.service.leaf.dto.*;
+import com.springddd.domain.util.PageResponse;
+import com.springddd.infrastructure.persistence.entity.LeafWorkerEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+import org.springframework.data.relational.core.query.Criteria;
+import org.springframework.data.relational.core.query.Query;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LeafWorkerQueryService {
+
+    private final R2dbcEntityTemplate r2dbcEntityTemplate;
+
+    private final LeafWorkerViewMapStruct mapStruct;
+
+    public Mono<PageResponse<LeafWorkerView>> index(LeafWorkerPageQuery query) {
+        Criteria criteria = Criteria.where("delete_status").is(false);
+        if (query.getWorkerId() != null) {
+            criteria = criteria.and(Criteria.where("worker_id").is(query.getWorkerId()));
+        }
+        if (query.getDatacenterId() != null) {
+            criteria = criteria.and(Criteria.where("datacenter_id").is(query.getDatacenterId()));
+        }
+        if (query.getIp() != null && !query.getIp().isEmpty()) {
+            criteria = criteria.and(Criteria.where("ip").is(query.getIp()));
+        }
+        if (query.getLastTimestamp() != null) {
+            criteria = criteria.and(Criteria.where("last_timestamp").is(query.getLastTimestamp()));
+        }
+        if (query.getPort() != null) {
+            criteria = criteria.and(Criteria.where("port").is(query.getPort()));
+        }
+        Query qry = Query.query(criteria)
+                .limit(query.getPageSize())
+                .offset((long) (query.getPageNum() - 1) * query.getPageSize());
+        Mono<List<LeafWorkerView>> list = r2dbcEntityTemplate.select(LeafWorkerEntity.class).matching(qry).all().collectList().map(mapStruct::toViews);
+        Mono<Long> count = r2dbcEntityTemplate.count(Query.query(criteria), LeafWorkerEntity.class);
+        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+    }
+
+    public Mono<PageResponse<LeafWorkerView>> recycle(LeafWorkerPageQuery query) {
+        Criteria criteria = Criteria.where("delete_status").is(true);
+        if (query.getWorkerId() != null) {
+            criteria = criteria.and(Criteria.where("worker_id").is(query.getWorkerId()));
+        }
+        if (query.getDatacenterId() != null) {
+            criteria = criteria.and(Criteria.where("datacenter_id").is(query.getDatacenterId()));
+        }
+        if (query.getIp() != null && !query.getIp().isEmpty()) {
+            criteria = criteria.and(Criteria.where("ip").is(query.getIp()));
+        }
+        if (query.getLastTimestamp() != null) {
+            criteria = criteria.and(Criteria.where("last_timestamp").is(query.getLastTimestamp()));
+        }
+        if (query.getPort() != null) {
+            criteria = criteria.and(Criteria.where("port").is(query.getPort()));
+        }
+        Query qry = Query.query(criteria)
+                .limit(query.getPageSize())
+                .offset((long) (query.getPageNum() - 1) * query.getPageSize());
+        Mono<List<LeafWorkerView>> list = r2dbcEntityTemplate.select(LeafWorkerEntity.class).matching(qry).all().collectList().map(mapStruct::toViews);
+        Mono<Long> count = r2dbcEntityTemplate.count(Query.query(criteria), LeafWorkerEntity.class);
+        return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), query.getPageNum(), query.getPageSize()));
+    }
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/RestoreLeafWorkerDomainServiceImpl.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/RestoreLeafWorkerDomainServiceImpl.java
@@ -1,0 +1,28 @@
+package com.springddd.application.service.leaf;
+
+import com.springddd.domain.auth.ReactiveSecurityUtils;
+import com.springddd.domain.leaf.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class RestoreLeafWorkerDomainServiceImpl implements RestoreLeafWorkerDomainService {
+
+    private final LeafWorkerDomainRepository domainRepository;
+    
+    @Override
+    public Mono<Void> restoreByIds(List<Long> ids) {
+        return Flux.fromIterable(ids)
+                .flatMap(id -> domainRepository.load(new LeafId(id))
+                        .flatMap(domain -> {
+                            domain.restore();
+                            return domainRepository.save(domain);
+                        }), ReactiveSecurityUtils.concurrency())
+                .then();
+    }
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/WipeLeafWorkerDomainServiceImpl.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/WipeLeafWorkerDomainServiceImpl.java
@@ -1,0 +1,21 @@
+package com.springddd.application.service.leaf;
+
+import com.springddd.domain.leaf.WipeLeafWorkerDomainService;
+import com.springddd.infrastructure.persistence.r2dbc.LeafWorkerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class WipeLeafWorkerDomainServiceImpl implements WipeLeafWorkerDomainService {
+
+    private final LeafWorkerRepository repository;
+
+    @Override
+    public Mono<Void> wipeByIds(List<Long> ids) {
+        return repository.deleteAllById(ids);
+    }
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/dto/LeafWorkerCommand.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/dto/LeafWorkerCommand.java
@@ -1,0 +1,23 @@
+package com.springddd.application.service.leaf.dto;
+
+import lombok.Data;
+import java.io.Serializable;
+
+@Data
+public class LeafWorkerCommand implements Serializable {
+
+    private Integer workerId;
+
+    private Integer datacenterId;
+
+    private String ip;
+
+    private Long lastTimestamp;
+
+    private Integer port;
+
+    private Long id;
+
+    private Boolean deleteStatus;
+
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/dto/LeafWorkerPageQuery.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/dto/LeafWorkerPageQuery.java
@@ -1,0 +1,18 @@
+package com.springddd.application.service.leaf.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class LeafWorkerPageQuery extends LeafWorkerQuery implements Serializable {
+
+    @NotNull(message = "pageNum不能为空")
+    private Integer pageNum;
+
+    @NotNull(message = "pageSize不能为空")
+    private Integer pageSize;
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/dto/LeafWorkerQuery.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/dto/LeafWorkerQuery.java
@@ -1,0 +1,25 @@
+package com.springddd.application.service.leaf.dto;
+
+import lombok.Data;
+import lombok.experimental.FieldNameConstants;
+import java.io.Serializable;
+
+@Data
+@FieldNameConstants
+public class LeafWorkerQuery implements Serializable {
+
+    private Integer workerId;
+
+    private Integer datacenterId;
+
+    private String ip;
+
+    private Long lastTimestamp;
+
+    private Integer port;
+
+    private Long id;
+
+    private Boolean deleteStatus;
+
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/dto/LeafWorkerView.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/dto/LeafWorkerView.java
@@ -1,0 +1,21 @@
+package com.springddd.application.service.leaf.dto;
+
+import lombok.Data;
+import java.io.Serializable;
+
+@Data
+public class LeafWorkerView implements Serializable {
+
+    private Integer workerId;
+
+    private Integer datacenterId;
+
+    private String ip;
+
+    private Long lastTimestamp;
+
+    private Integer port;
+
+    private Long id;
+
+}

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/dto/LeafWorkerViewMapStruct.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/leaf/dto/LeafWorkerViewMapStruct.java
@@ -1,0 +1,14 @@
+package com.springddd.application.service.leaf.dto;
+
+import com.springddd.infrastructure.persistence.entity.LeafWorkerEntity;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface LeafWorkerViewMapStruct {
+
+    LeafWorkerView toView(LeafWorkerEntity entity);
+
+    List<LeafWorkerView> toViews(List<LeafWorkerEntity> entities);
+}

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/Address.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/Address.java
@@ -1,0 +1,4 @@
+package com.springddd.domain.leaf;
+
+public record Address(String ip, Integer port) {
+}

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/DeleteLeafWorkerDomainService.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/DeleteLeafWorkerDomainService.java
@@ -1,0 +1,11 @@
+package com.springddd.domain.leaf;
+
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+public interface DeleteLeafWorkerDomainService {
+
+    Mono<Void> deleteByIds(List<Long> ids);
+
+}

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/ExtendInfo.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/ExtendInfo.java
@@ -1,0 +1,5 @@
+package com.springddd.domain.leaf;
+import java.time.LocalDateTime;
+
+public record ExtendInfo(Long lastTimestamp, LocalDateTime updateTime, Boolean deleteStatus) {
+}

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/LeafId.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/LeafId.java
@@ -1,0 +1,5 @@
+package com.springddd.domain.leaf;
+import com.springddd.domain.AggregateRootId;
+
+public record LeafId(Long value) implements AggregateRootId<Long> {
+}

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/LeafWorkerDomain.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/LeafWorkerDomain.java
@@ -1,0 +1,34 @@
+package com.springddd.domain.leaf;
+
+import com.springddd.domain.AbstractDomainMask;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class LeafWorkerDomain extends AbstractDomainMask {
+
+    private LeafId leafId;
+
+    private Worker worker;
+
+    private Address address;
+
+    private ExtendInfo extendInfo;
+
+    public void create() {}
+
+    public void update(Worker worker, Address address, ExtendInfo extendInfo) {
+        this.worker = worker;
+        this.address = address;
+        this.extendInfo = extendInfo;
+    }
+
+    public void delete() {
+        super.setDeleteStatus(true);
+    }
+
+    public void restore() {
+        super.setDeleteStatus(false);
+    }
+}

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/LeafWorkerDomainFactory.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/LeafWorkerDomainFactory.java
@@ -1,0 +1,6 @@
+package com.springddd.domain.leaf;
+
+public interface LeafWorkerDomainFactory {
+
+    LeafWorkerDomain newInstance(Worker worker, Address address, ExtendInfo extendInfo);
+}

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/LeafWorkerDomainRepository.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/LeafWorkerDomainRepository.java
@@ -1,0 +1,6 @@
+package com.springddd.domain.leaf;
+
+import com.springddd.domain.DomainRepository;
+
+public interface LeafWorkerDomainRepository extends DomainRepository<LeafId, LeafWorkerDomain> {
+}

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/RestoreLeafWorkerDomainService.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/RestoreLeafWorkerDomainService.java
@@ -1,0 +1,11 @@
+package com.springddd.domain.leaf;
+
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+public interface RestoreLeafWorkerDomainService {
+
+    Mono<Void> restoreByIds(List<Long> ids);
+
+}

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/WipeLeafWorkerDomainService.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/WipeLeafWorkerDomainService.java
@@ -1,0 +1,11 @@
+package com.springddd.domain.leaf;
+
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+public interface WipeLeafWorkerDomainService {
+
+    Mono<Void> wipeByIds(List<Long> ids);
+
+}

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/Worker.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/leaf/Worker.java
@@ -1,0 +1,4 @@
+package com.springddd.domain.leaf;
+
+public record Worker(Integer workerId, Integer datacenterId) {
+}

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/LeafWorkerDomainRepositoryImpl.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/LeafWorkerDomainRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.springddd.infrastructure.persistence;
+
+import com.springddd.domain.leaf.*;
+import com.springddd.infrastructure.persistence.entity.LeafWorkerEntity;
+import com.springddd.infrastructure.persistence.r2dbc.LeafWorkerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class LeafWorkerDomainRepositoryImpl implements LeafWorkerDomainRepository {
+
+    private final LeafWorkerRepository repository;
+
+    @Override
+    public Mono<LeafWorkerDomain> load(LeafId leafId) {
+        return repository.findById(leafId.value()).map(e -> {
+            LeafWorkerDomain domain = new LeafWorkerDomain();
+
+            domain.setLeafId(new LeafId(e.getId()));
+
+            domain.setWorker(new Worker(e.getWorkerId(), e.getDatacenterId()));
+            domain.setAddress(new Address(e.getIp(), e.getPort()));
+            domain.setExtendInfo(new ExtendInfo(e.getLastTimestamp(), e.getUpdateTime(), e.getDeleteStatus()));
+
+            domain.setDeleteStatus(e.getDeleteStatus());
+            domain.setUpdateTime(e.getUpdateTime());
+
+            return domain;
+        });
+    }
+
+    @Override
+    public Mono<Long> save(LeafWorkerDomain domain) {
+        LeafWorkerEntity entity = new LeafWorkerEntity();
+
+        entity.setId(Optional.ofNullable(domain.getLeafId()).map(LeafId::value).orElse(null));
+
+        entity.setWorkerId(domain.getWorker().workerId());
+        entity.setDatacenterId(domain.getWorker().datacenterId());
+        entity.setIp(domain.getAddress().ip());
+        entity.setPort(domain.getAddress().port());
+        entity.setLastTimestamp(domain.getExtendInfo().lastTimestamp());
+        entity.setUpdateTime(domain.getExtendInfo().updateTime());
+        entity.setDeleteStatus(domain.getExtendInfo().deleteStatus());
+
+        entity.setDeleteStatus(domain.getDeleteStatus());
+        entity.setUpdateTime(domain.getUpdateTime());
+
+        return repository.save(entity).map(LeafWorkerEntity::getId);
+    }
+}

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/LeafWorkerEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/LeafWorkerEntity.java
@@ -1,0 +1,42 @@
+package com.springddd.infrastructure.persistence.entity;
+
+import com.springddd.domain.util.IdGenerate;
+import lombok.Data;
+import org.springframework.data.annotation.*;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Data
+@Table("leaf_worker")
+public class LeafWorkerEntity {
+
+    @Column("worker_id")
+    private Integer workerId;
+
+    @Column("datacenter_id")
+    private Integer datacenterId;
+
+    @Column("ip")
+    private String ip;
+
+    @Column("last_timestamp")
+    private Long lastTimestamp;
+
+    @Column("port")
+    private Integer port;
+
+    @Id
+    @IdGenerate
+    @Column("id")
+    private Long id;
+
+    @Column("delete_status")
+    private Boolean deleteStatus;
+
+    @LastModifiedDate
+    @Column("update_time")
+    private LocalDateTime updateTime;
+
+}

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/r2dbc/LeafWorkerRepository.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/r2dbc/LeafWorkerRepository.java
@@ -1,0 +1,7 @@
+package com.springddd.infrastructure.persistence.r2dbc;
+
+import com.springddd.infrastructure.persistence.entity.LeafWorkerEntity;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+public interface LeafWorkerRepository extends ReactiveCrudRepository<LeafWorkerEntity, Long>{
+}

--- a/spring-ddd-interface-web/src/main/java/com/springddd/web/LeafWorkerController.java
+++ b/spring-ddd-interface-web/src/main/java/com/springddd/web/LeafWorkerController.java
@@ -1,0 +1,58 @@
+package com.springddd.web;
+
+import com.springddd.application.service.leaf.LeafWorkerCommandService;
+import com.springddd.application.service.leaf.LeafWorkerQueryService;
+import com.springddd.application.service.leaf.dto.LeafWorkerCommand;
+import com.springddd.application.service.leaf.dto.LeafWorkerPageQuery;
+import com.springddd.domain.util.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/leaf/leafWorker")
+public class LeafWorkerController {
+
+    private final LeafWorkerQueryService queryService;
+
+    private final LeafWorkerCommandService commandService;
+
+    @PostMapping("/index")
+    public Mono<ApiResponse> index(@RequestBody @Valid LeafWorkerPageQuery query) {
+        return ApiResponse.ok(queryService.index(query));
+    }
+
+    @PostMapping("/recycle")
+    public Mono<ApiResponse> recycle(@RequestBody @Valid LeafWorkerPageQuery query) {
+        return ApiResponse.ok(queryService.recycle(query));
+    }
+
+    @PostMapping("/create")
+    public Mono<ApiResponse> create(@RequestBody @Valid LeafWorkerCommand command) {
+        return ApiResponse.ok(commandService.create(command));
+    }
+
+    @PutMapping("/update")
+    public Mono<ApiResponse> update(@RequestBody @Valid LeafWorkerCommand command) {
+        return ApiResponse.ok(commandService.update(command));
+    }
+
+    @PostMapping("/delete")
+    public Mono<ApiResponse> delete(@RequestParam("ids") List<Long> ids) {
+        return ApiResponse.ok(commandService.delete(ids));
+    }
+
+    @PostMapping("/restore")
+    public Mono<ApiResponse> restore(@RequestParam("ids") List<Long> ids) {
+        return ApiResponse.ok(commandService.restore(ids));
+    }
+
+    @DeleteMapping("/wipe")
+    public Mono<ApiResponse> wipe(@RequestParam("ids") List<Long> ids) {
+        return ApiResponse.ok(commandService.wipe(ids));
+    }
+}


### PR DESCRIPTION
修复 commandService 模板：构建值对象时，对 createBy/createTime/updateBy/updateTime/version 传 null，避免生成代码编译失败。