### PR TITLE
feat(gen): default database name in table management

### DIFF
--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenTableInfoQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/GenTableInfoQueryService.java
@@ -8,9 +8,11 @@ import com.springddd.domain.util.PageResponse;
 import com.springddd.infrastructure.cache.keys.CacheKeys;
 import com.springddd.infrastructure.cache.util.ReactiveRedisCacheHelper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.r2dbc.core.DatabaseClient;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
@@ -34,11 +36,13 @@ public class GenTableInfoQueryService {
 
     private final ObjectMapper objectMapper;
 
-    public Mono<PageResponse<GenTableInfoView>> index(GenTableInfoPageQuery query) {
+    @Value("${spring.r2dbc.url:}")
+    private String r2dbcUrl;
 
-        if (ObjectUtils.isEmpty(query.getDatabaseName())) {
-            return Mono.empty();
-        }
+    public Mono<GenTableInfoPageResponse> index(GenTableInfoPageQuery query) {
+        String databaseName = ObjectUtils.isEmpty(query.getDatabaseName())
+                ? extractDatabaseName(r2dbcUrl)
+                : query.getDatabaseName();
 
         int offset = (query.getPageNum() - 1) * query.getPageSize();
         int limit = query.getPageSize();
@@ -63,12 +67,12 @@ public class GenTableInfoQueryService {
         dataSql.append(" ORDER BY create_time DESC LIMIT :limit OFFSET :offset");
 
         DatabaseClient.GenericExecuteSpec dataSpec = databaseClient.sql(dataSql.toString())
-                .bind("db", query.getDatabaseName())
+                .bind("db", databaseName)
                 .bind("limit", limit)
                 .bind("offset", offset);
 
         DatabaseClient.GenericExecuteSpec countSpec = databaseClient.sql(countSql.toString())
-                .bind("db", query.getDatabaseName());
+                .bind("db", databaseName);
 
         if (!ObjectUtils.isEmpty(query.getTableName())) {
             String tableNameLike = "%" + query.getTableName() + "%";
@@ -93,12 +97,29 @@ public class GenTableInfoQueryService {
                 .defaultIfEmpty(0L);
 
         return Mono.zip(data, count)
-                .map(tuple -> new PageResponse<>(
+                .map(tuple -> new GenTableInfoPageResponse(
                         tuple.getT1(),
                         tuple.getT2(),
                         query.getPageNum(),
-                        query.getPageSize()
+                        query.getPageSize(),
+                        databaseName
                 ));
+    }
+
+    private String extractDatabaseName(String url) {
+        if (!StringUtils.hasText(url)) {
+            return "";
+        }
+        int lastSlash = url.lastIndexOf('/');
+        if (lastSlash == -1 || lastSlash == url.length() - 1) {
+            return "";
+        }
+        String databaseName = url.substring(lastSlash + 1);
+        int queryStart = databaseName.indexOf('?');
+        if (queryStart != -1) {
+            databaseName = databaseName.substring(0, queryStart);
+        }
+        return databaseName;
     }
 
     public Mono<Map<String, Object>> buildData(String tableName) {

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/dto/GenTableInfoPageResponse.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/gen/dto/GenTableInfoPageResponse.java
@@ -1,0 +1,21 @@
+package com.springddd.application.service.gen.dto;
+
+import com.springddd.domain.util.PageResponse;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class GenTableInfoPageResponse extends PageResponse<GenTableInfoView> {
+
+    private String databaseName;
+
+    public GenTableInfoPageResponse(List<GenTableInfoView> items, long total, int pageNum, int pageSize, String databaseName) {
+        super(items, total, pageNum, pageSize);
+        this.databaseName = databaseName;
+    }
+}

--- a/spring-ddd-interface-web/src/main/java/com/springddd/web/GenTableController.java
+++ b/spring-ddd-interface-web/src/main/java/com/springddd/web/GenTableController.java
@@ -22,7 +22,9 @@ public class GenTableController {
 
     @PostMapping("/index")
     public Mono<ApiResponse> tableIndex(@RequestBody @Validated Mono<GenTableInfoPageQuery> query) {
-        return ApiResponse.validated(query, genTableInfoQueryService::index);
+        return query.flatMap(genTableInfoQueryService::index)
+                .map(ApiResponse::success)
+                .defaultIfEmpty(ApiResponse.empty());
     }
 
     @PostMapping("/preview")

--- a/spring-ddd-tests/pom.xml
+++ b/spring-ddd-tests/pom.xml
@@ -43,5 +43,20 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.springddd</groupId>
+            <artifactId>spring-ddd-application-service</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.springddd</groupId>
+            <artifactId>spring-ddd-interface-web</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.springddd</groupId>
+            <artifactId>spring-ddd-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/spring-ddd-tests/src/test/java/com/springddd/web/GenTableControllerTest.java
+++ b/spring-ddd-tests/src/test/java/com/springddd/web/GenTableControllerTest.java
@@ -1,0 +1,55 @@
+package com.springddd.web;
+
+import com.springddd.application.service.gen.GenTableInfoCommandService;
+import com.springddd.application.service.gen.GenTableInfoQueryService;
+import com.springddd.application.service.gen.dto.GenTableInfoPageQuery;
+import com.springddd.application.service.gen.dto.GenTableInfoPageResponse;
+import com.springddd.domain.util.ApiResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GenTableControllerTest {
+
+    @Mock
+    private GenTableInfoQueryService genTableInfoQueryService;
+
+    @Mock
+    private GenTableInfoCommandService genTableInfoCommandService;
+
+    @InjectMocks
+    private GenTableController genTableController;
+
+    @Test
+    void tableIndex_shouldReturnDatabaseNameInPageResponse() {
+        GenTableInfoPageResponse pageResponse = new GenTableInfoPageResponse(
+                Collections.emptyList(),
+                0L,
+                1,
+                10,
+                "test_ddd"
+        );
+        when(genTableInfoQueryService.index(any(GenTableInfoPageQuery.class))).thenReturn(Mono.just(pageResponse));
+
+        Mono<ApiResponse> result = genTableController.tableIndex(Mono.just(new GenTableInfoPageQuery()));
+
+        StepVerifier.create(result)
+                .assertNext(apiResponse -> {
+                    assertEquals(0, apiResponse.getCode());
+                    GenTableInfoPageResponse data = (GenTableInfoPageResponse) apiResponse.getData();
+                    assertEquals("test_ddd", data.getDatabaseName());
+                })
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
Use configured r2dbc database name when query databaseName is empty, and return it in GenTableInfoPageResponse so the frontend can prefill the search form.