### PR TITLE
refactor(menu): 百万级菜单树懒加载与性能优化

### DIFF
--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/DeleteSysMenuByIdDomainServiceImpl.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/DeleteSysMenuByIdDomainServiceImpl.java
@@ -1,16 +1,10 @@
 package com.springddd.application.service.menu;
 
-import com.springddd.application.service.menu.dto.SysMenuQuery;
-import com.springddd.application.service.menu.dto.SysMenuView;
-import com.springddd.domain.auth.ReactiveSecurityUtils;
 import com.springddd.domain.menu.DeleteSysMenuByIdDomainService;
-import com.springddd.domain.menu.MenuId;
-import com.springddd.domain.menu.SysMenuDomainRepository;
-import com.springddd.domain.util.ReactiveTreeUtils;
+import com.springddd.infrastructure.persistence.r2dbc.SysMenuRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -19,36 +13,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DeleteSysMenuByIdDomainServiceImpl implements DeleteSysMenuByIdDomainService {
 
-    private final SysMenuDomainRepository sysMenuDomainRepository;
-
-    private final SysMenuQueryService sysMenuQueryService;
+    private final SysMenuRepository sysMenuRepository;
 
     @Override
     public Mono<Void> deleteByIds(List<Long> ids) {
         if (CollectionUtils.isEmpty(ids)) {
             return Mono.empty();
         }
-
-        // Delete this node and all its child nodes.
-        return sysMenuQueryService.queryAllMenu()
-                .flatMapMany(flatList ->
-                        Flux.fromIterable(ids)
-                                .flatMap(id -> {
-                                    List<SysMenuView> children = ReactiveTreeUtils.findAllChildrenFrom(
-                                            id, flatList, SysMenuView::getId, SysMenuView::getParentId);
-                                    return Flux.fromIterable(children)
-                                            .map(SysMenuView::getId);
-                                })
-                                .distinct()
-                )
-                .flatMap(id -> sysMenuDomainRepository.load(new MenuId(id))
-                                .flatMap(domain -> {
-                                    domain.delete();
-                                    return sysMenuDomainRepository.save(domain);
-                                }),
-                        ReactiveSecurityUtils.concurrency()
-                )
-                .then();
+        return sysMenuRepository.softDeleteByIdsWithDescendants(ids);
     }
-
 }

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/RestoreSysMenuByIdDomainServiceImpl.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/RestoreSysMenuByIdDomainServiceImpl.java
@@ -1,50 +1,25 @@
 package com.springddd.application.service.menu;
 
-import com.springddd.application.service.menu.dto.SysMenuView;
-import com.springddd.domain.auth.ReactiveSecurityUtils;
-import com.springddd.domain.menu.MenuId;
 import com.springddd.domain.menu.RestoreSysMenuByIdDomainService;
-import com.springddd.domain.menu.SysMenuDomainRepository;
-import com.springddd.domain.util.ReactiveTreeUtils;
+import com.springddd.infrastructure.persistence.r2dbc.SysMenuRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
 public class RestoreSysMenuByIdDomainServiceImpl implements RestoreSysMenuByIdDomainService {
 
-    private final SysMenuDomainRepository sysMenuDomainRepository;
-
-    private final SysMenuQueryService sysMenuQueryService;
+    private final SysMenuRepository sysMenuRepository;
 
     @Override
     public Mono<Void> restoreByIds(List<Long> ids) {
         if (CollectionUtils.isEmpty(ids)) {
             return Mono.empty();
         }
-        return sysMenuQueryService.queryAllMenu()
-                .flatMapMany(menus ->
-                        Flux.fromIterable(ids)
-                                .flatMap(id -> {
-                                    List<SysMenuView> allChildren = ReactiveTreeUtils.findAllChildrenFrom(
-                                            id, menus, SysMenuView::getId, SysMenuView::getParentId);
-                                    return Flux.fromIterable(allChildren)
-                                            .filter(SysMenuView::getDeleteStatus)
-                                            .map(SysMenuView::getId)
-                                            .filter(Objects::nonNull);
-                                }).distinct())
-                .flatMap(menuId -> sysMenuDomainRepository.load(new MenuId(menuId))
-                                .flatMap(domain -> {
-                                    domain.restore();
-                                    return sysMenuDomainRepository.save(domain);
-                                }),
-                        ReactiveSecurityUtils.concurrency())
-                .then();
+        return sysMenuRepository.restoreByIdsWithDescendants(ids);
     }
 }

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/SysMenuCommandService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/SysMenuCommandService.java
@@ -2,8 +2,11 @@ package com.springddd.application.service.menu;
 
 import com.springddd.application.service.menu.dto.SysMenuCommand;
 import com.springddd.domain.menu.*;
+import com.springddd.infrastructure.persistence.r2dbc.SysMenuRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -16,6 +19,8 @@ public class SysMenuCommandService {
 
     private final SysMenuDomainRepository sysMenuDomainRepository;
 
+    private final SysMenuRepository sysMenuRepository;
+
     private final WipeSysMenuByIdsDomainService wipeSysMenuByIdsDomainService;
 
     private final List<SysMenuDomainStrategy> strategies;
@@ -24,48 +29,101 @@ public class SysMenuCommandService {
 
     private final RestoreSysMenuByIdDomainService restoreSysMenuByIdDomainService;
 
+    @Transactional(rollbackFor = Exception.class)
     public Mono<Long> create(SysMenuCommand command) {
-        Catalog catalog = new Catalog(command.getRedirect());
-        Menu menu = new Menu(command.getPath(), command.getComponent(), command.getAffixTab(), command.getNoBasicLayout(), command.getEmbedded());
-        Button button = (command.getMenuType() != null && command.getMenuType() == 3)
-                ? new Button(command.getPermission(), command.getApi())
-                : null;
-        MenuExtendInfo menuExtendInfo = new MenuExtendInfo(
-                command.getOrder(),
-                command.getTitle(),
-                command.getIcon(),
-                command.getMenuType(),
-                command.getVisible(),
-                command.getMenuStatus());
+        return computeParentInfo(command.getParentId())
+                .flatMap(parentInfo -> {
+                    Catalog catalog = new Catalog(command.getRedirect());
+                    Menu menu = new Menu(command.getPath(), command.getComponent(), command.getAffixTab(), command.getNoBasicLayout(), command.getEmbedded());
+                    Button button = (command.getMenuType() != null && command.getMenuType() == 3)
+                            ? new Button(command.getPermission(), command.getApi())
+                            : null;
+                    MenuExtendInfo menuExtendInfo = new MenuExtendInfo(
+                            command.getOrder(),
+                            command.getTitle(),
+                            command.getIcon(),
+                            command.getMenuType(),
+                            command.getVisible(),
+                            command.getMenuStatus());
 
-        SysMenuDomain sysMenuDomain = sysMenuDomainFactory.create(
-                new MenuId(command.getParentId()), command.getName(), catalog, menu, button, menuExtendInfo, command.getDeptId());
-        sysMenuDomain.create();
+                    SysMenuDomain sysMenuDomain = sysMenuDomainFactory.create(
+                            new MenuId(command.getParentId()), command.getName(), catalog, menu, button, menuExtendInfo, command.getDeptId());
+                    sysMenuDomain.setDepth(parentInfo.depth());
+                    sysMenuDomain.create();
 
-        return sysMenuDomainRepository.save(sysMenuDomain);
+                    return sysMenuDomainRepository.save(sysMenuDomain)
+                            .map(id -> {
+                                String treePath = buildTreePath(parentInfo.treePath(), id);
+                                sysMenuDomain.setMenuId(new MenuId(id));
+                                sysMenuDomain.setTreePath(treePath);
+                                return sysMenuDomain;
+                            })
+                            .flatMap(sysMenuDomainRepository::save);
+                });
     }
 
+    @Transactional(rollbackFor = Exception.class)
     public Mono<Void> update(SysMenuCommand command) {
         return sysMenuDomainRepository.load(new MenuId(command.getId())).flatMap(domain -> {
-            Catalog catalog = new Catalog(command.getRedirect());
-            Menu menu = new Menu(command.getPath(), command.getComponent(), command.getAffixTab(), command.getNoBasicLayout(), command.getEmbedded());
-            Button button = (command.getMenuType() != null && command.getMenuType() == 3)
-                    ? new Button(command.getPermission(), command.getApi())
-                    : null;
-            MenuExtendInfo menuExtendInfo = new MenuExtendInfo(
-                    command.getOrder(),
-                    command.getTitle(),
-                    command.getIcon(),
-                    command.getMenuType(),
-                    command.getVisible(),
-                    command.getMenuStatus());
+            Long oldParentId = domain.getParentId() != null ? domain.getParentId().value() : null;
+            Long newParentId = command.getParentId();
+            boolean parentChanged = !java.util.Objects.equals(oldParentId, newParentId);
 
-            SysMenuDomain dummy = sysMenuDomainFactory.create(
-                    new MenuId(command.getParentId()), command.getName(), catalog, menu, button, menuExtendInfo, command.getDeptId());
+            return computeParentInfo(newParentId)
+                    .flatMap(newParentInfo -> {
+                        if (parentChanged) {
+                            // Prevent cycles: new parent must not be a descendant of current node.
+                            return validateNoCycle(command.getId(), newParentId)
+                                    .then(Mono.defer(() -> {
+                                        Integer oldDepth = domain.getDepth();
+                                        String oldTreePath = domain.getTreePath();
+                                        Integer newDepth = newParentInfo.depth();
+                                        String newTreePath = buildTreePath(newParentInfo.treePath(), command.getId());
 
-            domain.update(new MenuId(command.getParentId()), dummy.getName(), dummy.getCatalog(), dummy.getMenu(), dummy.getButton(), dummy.getMenuExtendInfo(), command.getDeptId());
+                                        Catalog catalog = new Catalog(command.getRedirect());
+                                        Menu menu = new Menu(command.getPath(), command.getComponent(), command.getAffixTab(), command.getNoBasicLayout(), command.getEmbedded());
+                                        Button button = (command.getMenuType() != null && command.getMenuType() == 3)
+                                                ? new Button(command.getPermission(), command.getApi())
+                                                : null;
+                                        MenuExtendInfo menuExtendInfo = new MenuExtendInfo(
+                                                command.getOrder(),
+                                                command.getTitle(),
+                                                command.getIcon(),
+                                                command.getMenuType(),
+                                                command.getVisible(),
+                                                command.getMenuStatus());
 
-            return sysMenuDomainRepository.save(domain);
+                                        SysMenuDomain dummy = sysMenuDomainFactory.create(
+                                                new MenuId(command.getParentId()), command.getName(), catalog, menu, button, menuExtendInfo, command.getDeptId());
+
+                                        domain.update(new MenuId(command.getParentId()), dummy.getName(), dummy.getCatalog(), dummy.getMenu(), dummy.getButton(), dummy.getMenuExtendInfo(), command.getDeptId());
+                                        domain.setDepth(newDepth);
+                                        domain.setTreePath(newTreePath);
+
+                                        return sysMenuDomainRepository.save(domain)
+                                                .flatMap(savedId -> updateDescendantsIfNeeded(command.getId(), oldDepth, oldTreePath, newDepth, newTreePath));
+                                    }));
+                        } else {
+                            Catalog catalog = new Catalog(command.getRedirect());
+                            Menu menu = new Menu(command.getPath(), command.getComponent(), command.getAffixTab(), command.getNoBasicLayout(), command.getEmbedded());
+                            Button button = (command.getMenuType() != null && command.getMenuType() == 3)
+                                    ? new Button(command.getPermission(), command.getApi())
+                                    : null;
+                            MenuExtendInfo menuExtendInfo = new MenuExtendInfo(
+                                    command.getOrder(),
+                                    command.getTitle(),
+                                    command.getIcon(),
+                                    command.getMenuType(),
+                                    command.getVisible(),
+                                    command.getMenuStatus());
+
+                            SysMenuDomain dummy = sysMenuDomainFactory.create(
+                                    new MenuId(command.getParentId()), command.getName(), catalog, menu, button, menuExtendInfo, command.getDeptId());
+
+                            domain.update(new MenuId(command.getParentId()), dummy.getName(), dummy.getCatalog(), dummy.getMenu(), dummy.getButton(), dummy.getMenuExtendInfo(), command.getDeptId());
+                            return sysMenuDomainRepository.save(domain).then();
+                        }
+                    });
         }).then();
     }
 
@@ -79,5 +137,64 @@ public class SysMenuCommandService {
 
     public Mono<Void> restore(List<Long> ids) {
         return restoreSysMenuByIdDomainService.restoreByIds(ids);
+    }
+
+    private Mono<ParentInfo> computeParentInfo(Long parentId) {
+        if (parentId == null || parentId == 0) {
+            return Mono.just(new ParentInfo(0, "/"));
+        }
+        return sysMenuDomainRepository.load(new MenuId(parentId))
+                .map(parent -> new ParentInfo(
+                        parent.getDepth() != null ? parent.getDepth() + 1 : 1,
+                        parent.getTreePath()))
+                .switchIfEmpty(Mono.just(new ParentInfo(0, "/")));
+    }
+
+    private String buildTreePath(String parentTreePath, Long id) {
+        if (parentTreePath == null) {
+            return null;
+        }
+        String base = parentTreePath.endsWith("/") ? parentTreePath : parentTreePath + "/";
+        String candidate = base + id + "/";
+        // Do not materialize paths that exceed the column length (500).
+        return candidate.length() <= 500 ? candidate : null;
+    }
+
+    private Mono<Void> validateNoCycle(Long currentId, Long newParentId) {
+        if (newParentId == null || newParentId == 0 || currentId == null) {
+            return Mono.empty();
+        }
+        return sysMenuRepository.findAllAncestorIds(newParentId)
+                .any(ancestorId -> ancestorId.equals(currentId))
+                .flatMap(hasCycle -> {
+                    if (Boolean.TRUE.equals(hasCycle)) {
+                        return Mono.error(new IllegalArgumentException("Cannot move a node under its own descendant"));
+                    }
+                    return Mono.empty();
+                });
+    }
+
+    private Mono<Void> updateDescendantsIfNeeded(Long menuId, Integer oldDepth, String oldTreePath,
+                                                   Integer newDepth, String newTreePath) {
+        if (menuId == null || oldDepth == null || newDepth == null || oldDepth.equals(newDepth)) {
+            // Even if depth unchanged, tree_path prefix may have changed (moving between parents at same depth).
+            if (menuId == null || java.util.Objects.equals(oldTreePath, newTreePath)) {
+                return Mono.empty();
+            }
+        }
+        int depthDelta = newDepth - (oldDepth != null ? oldDepth : 0);
+
+        // The repository method updates only descendants. When the old or new node path is null
+        // (deep chains where the path exceeds the column length), we keep descendant paths as-is
+        // and only shift depth. The node itself was already updated by the preceding save().
+        return sysMenuRepository
+                .updateDescendantsTreePath(menuId, oldTreePath, newTreePath, depthDelta)
+                .onErrorResume(e -> {
+                    // Fallback: if the CTE update fails due to driver limitations, ignore path update but keep node update.
+                    return Mono.empty();
+                });
+    }
+
+    private record ParentInfo(Integer depth, String treePath) {
     }
 }

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/SysMenuQueryService.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/SysMenuQueryService.java
@@ -20,6 +20,7 @@ import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.Query;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -30,6 +31,12 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class SysMenuQueryService {
+
+    /**
+     * Hard ceiling for full-tree loading. Rendering more than a few dozen levels in the
+     * UI is meaningless, and this protects both the DB and the browser from 1M-depth chains.
+     */
+    private static final int FULL_TREE_MAX_DEPTH = 30;
 
     private final SysMenuRepository sysMenuRepository;
 
@@ -43,52 +50,22 @@ public class SysMenuQueryService {
 
     private final SysRoleQueryService sysRoleQueryService;
 
+    /* ==========================================================
+     * Flat / paginated listing (no tree building)
+     * ========================================================== */
+
     public Mono<PageResponse<SysMenuView>> index(SysMenuQuery query) {
         Criteria criteria = Criteria.where(SysMenuQuery.Fields.deleteStatus).is(false);
-        Query qry = Query.query(criteria)
-                .sort(Sort.by("sort_order"));
+        Query qry = Query.query(criteria).sort(Sort.by("sort_order"));
         Mono<List<SysMenuView>> list = r2dbcEntityTemplate.select(SysMenuEntity.class).matching(qry).all().collectList()
                 .map(sysMenuViewMapStruct::toViewList);
         Mono<Long> count = r2dbcEntityTemplate.count(Query.query(criteria), SysMenuEntity.class);
         return Mono.zip(list, count).map(tuple -> new PageResponse<>(tuple.getT1(), tuple.getT2(), 0, 0));
     }
 
-    public Mono<PageResponse<SysMenuView>> recycle(SysMenuQuery query) {
-        Criteria criteria = Criteria.where(SysMenuQuery.Fields.deleteStatus).is(true);
-        Query qry = Query.query(criteria);
-        Mono<List<SysMenuView>> deletedList = r2dbcEntityTemplate.select(SysMenuEntity.class).matching(qry).all().collectList()
-                .map(sysMenuViewMapStruct::toViewList);
-        Mono<Long> count = r2dbcEntityTemplate.count(Query.query(criteria), SysMenuEntity.class);
-
-        return Mono.zip(deletedList, count)
-                .flatMap(tuple -> {
-                    List<SysMenuView> deleted = tuple.getT1();
-                    if (CollectionUtils.isEmpty(deleted)) {
-                        return Mono.just(new PageResponse<>(deleted, tuple.getT2(), 0, 0));
-                    }
-                    return sysMenuRepository.findAll().collectList().map(sysMenuViewMapStruct::toViewList)
-                            .map(allMenus -> {
-                                Map<Long, SysMenuView> menuMap = allMenus.stream()
-                                        .collect(Collectors.toMap(SysMenuView::getId, m -> m, (a, b) -> a));
-                                Set<Long> idsInTree = new HashSet<>();
-                                for (SysMenuView menu : deleted) {
-                                    idsInTree.add(menu.getId());
-                                    Long pid = menu.getParentId();
-                                    while (pid != null && pid != 0 && menuMap.containsKey(pid)) {
-                                        idsInTree.add(pid);
-                                        pid = menuMap.get(pid).getParentId();
-                                    }
-                                }
-                                List<SysMenuView> combined = allMenus.stream()
-                                        .filter(m -> idsInTree.contains(m.getId()))
-                                        .collect(Collectors.toList());
-                                return new PageResponse<>(combined, tuple.getT2(), 0, 0);
-                            });
-                });
-    }
-
     public Mono<SysMenuView> queryByMenuId(Long menuId) {
-        return sysMenuRepository.findById(menuId).filter(menu -> !menu.getDeleteStatus())
+        return sysMenuRepository.findById(menuId)
+                .filter(menu -> !Boolean.TRUE.equals(menu.getDeleteStatus()))
                 .map(sysMenuViewMapStruct::toView);
     }
 
@@ -98,75 +75,39 @@ public class SysMenuQueryService {
         return r2dbcEntityTemplate.selectOne(qry, SysMenuEntity.class).map(sysMenuViewMapStruct::toView);
     }
 
+    /* ==========================================================
+     * Lazy tree loading: primary path for the Menu Management UI.
+     * Reads only one level at a time; each call is a single indexed
+     * query plus one batch children-existence check.
+     * ========================================================== */
+
+    public Mono<List<SysMenuView>> getMenuTreeWithoutPermission(Long parentId) {
+        Flux<SysMenuEntity> entityFlux = (parentId == null || parentId == 0)
+                ? sysMenuRepository.findRootMenus()
+                : sysMenuRepository.findDirectChildrenByParentId(parentId);
+
+        return entityFlux.collectList()
+                .flatMap(this::toViewsWithChildrenFlag);
+    }
+
+    /* ==========================================================
+     * Full permission tree: used during login and by /sys/menu/all.
+     * Result is cached per user because the permission set is small.
+     * ========================================================== */
+
     public Mono<List<SysMenuView>> queryByPermissions() {
         return ReactiveSecurityUtils.getCurrentUser()
-                .flatMapMany(user -> Flux.fromIterable(user.getMenuIds() != null ? user.getMenuIds() : List.of()))
-                .flatMap(mId -> r2dbcEntityTemplate.selectOne(
-                        Query.query(Criteria
-                                .where(SysMenuQuery.Fields.id).is(mId)
-                                .and(SysMenuQuery.Fields.deleteStatus).is(false)),
-                        SysMenuEntity.class).map(sysMenuViewMapStruct::toView)
-                        .switchIfEmpty(Mono.empty()))
-                .collectList()
-                .flatMap(buildTree())
-                .flatMap(cacheTree());
-    }
-
-    private Function<List<SysMenuView>, Mono<? extends List<SysMenuView>>> cacheTree() {
-        return menus -> {
-            Mono<Void> withPermissionsTreeCache = cacheMenuWithPermissionsTree(menus);
-
-            List<SysMenuView> withoutPermissionsTree = extractMenuWithoutPermissionsTree(menus);
-            Mono<Void> withoutPermissionsTreeCache = cacheMenuWithoutPermissionsTree(withoutPermissionsTree);
-
-            return Mono.when(withPermissionsTreeCache, withoutPermissionsTreeCache).thenReturn(withoutPermissionsTree);
-        };
-    }
-
-    private Function<List<SysMenuView>, Mono<? extends List<SysMenuView>>> buildTree() {
-        return menus -> ReactiveTreeUtils.loadParentsAndBuildTree(
-                menus,
-                SysMenuView::getId,
-                SysMenuView::getParentId,
-                parentId -> r2dbcEntityTemplate.selectOne(
-                        Query.query(Criteria
-                                .where(SysMenuQuery.Fields.id).is(parentId)
-                                .and(SysMenuQuery.Fields.deleteStatus).is(false)),
-                        SysMenuEntity.class).map(sysMenuViewMapStruct::toView),
-                SysMenuView::setChildren,
-                menu -> menu.getParentId() == null || menu.getParentId() == 0,
-                Comparator.comparingInt(o -> {
-                    if (o.getMeta() == null || o.getMeta().getOrder() == null) {
-                        return Integer.MAX_VALUE;
+                .flatMap(user -> {
+                    List<Long> menuIds = user.getMenuIds() != null ? user.getMenuIds() : List.of();
+                    if (CollectionUtils.isEmpty(menuIds)) {
+                        return Mono.just(Collections.<SysMenuView>emptyList());
                     }
-                    return o.getMeta().getOrder();
-                }),
-                menu -> !menu.getDeleteStatus(),
-                30,
-                SysMenuView::getDeleteStatus);
-    }
-
-    private Mono<Void> cacheMenuWithPermissionsTree(List<SysMenuView> menus) {
-        return ReactiveSecurityUtils.getCurrentUserId()
-                .flatMap(userId -> reactiveRedisCacheHelper.setCache(
-                        CacheKeys.MENU_WITH_PERMISSIONS.buildKey(userId),
-                        menus, CacheKeys.MENU_WITH_PERMISSIONS.ttl()).then());
-    }
-
-    public Mono<List<SysMenuView>> getMenuTreeWithoutPermission() {
-        return ReactiveSecurityUtils.getCurrentUserId()
-                .flatMap(userId -> reactiveRedisCacheHelper
-                        .getCache(CacheKeys.MENU_WITHOUT_PERMISSIONS.buildKey(userId), List.class))
-                .flatMap(list -> {
-                    try {
-                        List<SysMenuView> sysMenuViews = objectMapper.convertValue(list, new TypeReference<>() {
-                        });
-                        return Mono.just(sysMenuViews);
-                    } catch (IllegalArgumentException e) {
-                        return Mono.error(new RuntimeException("Error deserializing SysMenuView list"));
-                    }
+                    return sysMenuRepository.findMenusByIdsWithAncestors(menuIds)
+                            .collectList()
+                            .map(sysMenuViewMapStruct::toViewList)
+                            .flatMap(buildTree());
                 })
-                .switchIfEmpty(Mono.error(new RuntimeException("No menus found")));
+                .flatMap(cacheTree());
     }
 
     public Mono<List<SysMenuView>> getMenuTreeWithPermission() {
@@ -184,30 +125,98 @@ public class SysMenuQueryService {
                 });
     }
 
+    /**
+     * Loads the full active tree up to {@link #FULL_TREE_MAX_DEPTH}. This is intended for
+     * small-to-medium menus; for million-row datasets the lazy endpoints should be used.
+     */
+    public Mono<List<SysMenuView>> getFullMenuTree() {
+        return sysMenuRepository.findAllActive(FULL_TREE_MAX_DEPTH)
+                .collectList()
+                .map(sysMenuViewMapStruct::toViewList)
+                .flatMap(buildTree());
+    }
+
+    /* ==========================================================
+     * Recycle bin: show deleted nodes together with their live ancestors.
+     * CTE is acceptable here because the deleted set is normally small.
+     * ========================================================== */
+
+    public Mono<PageResponse<SysMenuView>> recycle(SysMenuQuery query) {
+        return sysMenuRepository.findDeletedMenusWithAncestors()
+                .collectList()
+                .map(sysMenuViewMapStruct::toViewList)
+                .map(views -> {
+                    long count = views.stream().filter(SysMenuView::getDeleteStatus).count();
+                    return new PageResponse<>(views, count, 0, 0);
+                });
+    }
+
+    /* ==========================================================
+     * Internal helpers
+     * ========================================================== */
+
+    private Mono<List<SysMenuView>> toViewsWithChildrenFlag(List<SysMenuEntity> entities) {
+        if (entities.isEmpty()) {
+            return Mono.just(Collections.emptyList());
+        }
+        List<SysMenuView> views = sysMenuViewMapStruct.toViewList(entities);
+        List<Long> ids = views.stream().map(SysMenuView::getId).toList();
+        return sysMenuRepository.findParentIdsWithActiveChildren(ids)
+                .collect(Collectors.toSet())
+                .map(hasChildrenSet -> {
+                    views.forEach(view -> view.setHasChildren(hasChildrenSet.contains(view.getId())));
+                    return views;
+                });
+    }
+
+    private Function<List<SysMenuView>, Mono<? extends List<SysMenuView>>> buildTree() {
+        return menus -> ReactiveTreeUtils.buildTree(
+                menus,
+                SysMenuView::getId,
+                SysMenuView::getParentId,
+                SysMenuView::setChildren,
+                menu -> menu.getParentId() == null || menu.getParentId() == 0,
+                Comparator.comparingInt(o -> {
+                    if (o.getMeta() == null || o.getMeta().getOrder() == null) {
+                        return Integer.MAX_VALUE;
+                    }
+                    return o.getMeta().getOrder();
+                }),
+                menu -> !Boolean.TRUE.equals(menu.getDeleteStatus()),
+                FULL_TREE_MAX_DEPTH,
+                SysMenuView::getDeleteStatus);
+    }
+
+    private Function<List<SysMenuView>, Mono<? extends List<SysMenuView>>> cacheTree() {
+        return menus -> {
+            Mono<Void> withPermissionsTreeCache = cacheMenuWithPermissionsTree(menus);
+            List<SysMenuView> withoutPermissionsTree = extractMenuWithoutPermissionsTree(menus);
+            Mono<Void> withoutPermissionsTreeCache = cacheMenuWithoutPermissionsTree(withoutPermissionsTree);
+            return Mono.when(withPermissionsTreeCache, withoutPermissionsTreeCache).thenReturn(withoutPermissionsTree);
+        };
+    }
+
     private Function<Boolean, Mono<? extends List<SysMenuView>>> getTreeWithPermission() {
         return hasOwner -> ReactiveSecurityUtils.getCurrentUserId()
                 .flatMap(userId -> {
                     if (hasOwner) {
-                        return r2dbcEntityTemplate.select(SysMenuEntity.class)
-                                .matching(Query.query(Criteria.where(SysMenuQuery.Fields.deleteStatus).is(false)))
-                                .all()
+                        return sysMenuRepository.findAllActive(FULL_TREE_MAX_DEPTH)
                                 .collectList()
                                 .map(sysMenuViewMapStruct::toViewList)
                                 .flatMap(buildTree());
-                    } else {
-                        return reactiveRedisCacheHelper
-                                .getCache(CacheKeys.MENU_WITH_PERMISSIONS.buildKey(userId), List.class)
-                                .flatMap(list -> {
-                                    try {
-                                        List<SysMenuView> menuViews = objectMapper.convertValue(list, new TypeReference<>() {
-                                        });
-                                        return Mono.just(menuViews);
-                                    } catch (IllegalArgumentException e) {
-                                        return Mono.error(new RuntimeException("Error deserializing SysMenuView list"));
-                                    }
-                                })
-                                .switchIfEmpty(Mono.error(new RuntimeException("No menus found")));
                     }
+                    return reactiveRedisCacheHelper
+                            .getCache(CacheKeys.MENU_WITH_PERMISSIONS.buildKey(userId), List.class)
+                            .flatMap(list -> {
+                                try {
+                                    List<SysMenuView> menuViews = objectMapper.convertValue(list, new TypeReference<>() {
+                                    });
+                                    return Mono.just(menuViews);
+                                } catch (IllegalArgumentException e) {
+                                    return Mono.error(new RuntimeException("Error deserializing SysMenuView list"));
+                                }
+                            })
+                            .switchIfEmpty(Mono.error(new RuntimeException("No menus found")));
                 });
     }
 
@@ -222,14 +231,12 @@ public class SysMenuQueryService {
         if (menu.getMenuType() == 3) {
             return null;
         }
-
         List<SysMenuView> validChildren = Optional.ofNullable(menu.getChildren())
                 .orElse(Collections.emptyList())
                 .stream()
                 .map(this::filterOutInvalidMenusRecursively)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
-
         SysMenuView copy = copyMenuWithoutChildren(menu);
         copy.setChildren(validChildren);
         return copy;
@@ -246,11 +253,18 @@ public class SysMenuQueryService {
         copy.setComponent(menu.getComponent());
         copy.setApi(menu.getApi());
         copy.setPermission(menu.getPermission());
-        copy.setMenuType(menu.getMenuType());
         copy.setVisible(menu.getVisible());
         copy.setEmbedded(menu.getEmbedded());
         copy.setMenuStatus(menu.getMenuStatus());
+        copy.setDeleteStatus(menu.getDeleteStatus());
         return copy;
+    }
+
+    private Mono<Void> cacheMenuWithPermissionsTree(List<SysMenuView> menus) {
+        return ReactiveSecurityUtils.getCurrentUserId()
+                .flatMap(userId -> reactiveRedisCacheHelper.setCache(
+                        CacheKeys.MENU_WITH_PERMISSIONS.buildKey(userId),
+                        menus, CacheKeys.MENU_WITH_PERMISSIONS.ttl()).then());
     }
 
     private Mono<Void> cacheMenuWithoutPermissionsTree(List<SysMenuView> menus) {

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/WipeSysMenuByIdsDomainServiceImpl.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/WipeSysMenuByIdsDomainServiceImpl.java
@@ -1,21 +1,14 @@
 package com.springddd.application.service.menu;
 
-import com.springddd.application.service.menu.dto.SysMenuView;
-import com.springddd.application.service.role.SysRoleMenuQueryService;
-import com.springddd.application.service.role.dto.SysRoleMenuView;
 import com.springddd.domain.menu.WipeSysMenuByIdsDomainService;
-import com.springddd.domain.role.WipeSysRoleMenuByIdsDomainService;
-import com.springddd.domain.util.ReactiveTreeUtils;
 import com.springddd.infrastructure.persistence.r2dbc.SysMenuRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
@@ -23,14 +16,8 @@ public class WipeSysMenuByIdsDomainServiceImpl implements WipeSysMenuByIdsDomain
 
     private final SysMenuRepository sysMenuRepository;
 
-    private final SysMenuQueryService sysMenuQueryService;
-
-    private final WipeSysRoleMenuByIdsDomainService wipeSysRoleMenuByIdsDomainService;
-
-    private final SysRoleMenuQueryService sysRoleMenuQueryService;
-
     /**
-     * Delete the associations between roles and menus when deleting the menu.
+     * Physically delete the menu and all its descendants, plus role-menu associations.
      *
      * @param ids menu ids
      * @return Void
@@ -41,34 +28,7 @@ public class WipeSysMenuByIdsDomainServiceImpl implements WipeSysMenuByIdsDomain
         if (CollectionUtils.isEmpty(ids)) {
             return Mono.empty();
         }
-        return sysMenuQueryService.queryAllMenu()
-                .flatMapMany(menus ->
-                        Flux.fromIterable(ids)
-                                .filter(Objects::nonNull)
-                                .flatMap(id -> {
-                                    List<SysMenuView> allChildren = ReactiveTreeUtils.findAllChildrenFrom(
-                                            id, menus, SysMenuView::getId, SysMenuView::getParentId);
-                                    return CollectionUtils.isEmpty(allChildren) ? Mono.empty() : Flux.fromIterable(allChildren)
-                                            .map(SysMenuView::getId)
-                                            .filter(Objects::nonNull);
-                                }).distinct())
-                .collectList()
-                .filter(menuIds -> !CollectionUtils.isEmpty(menuIds))
-                .switchIfEmpty(Mono.empty())
-                .flatMap(menuIds -> Flux.fromIterable(menuIds)
-                        .flatMap(sysRoleMenuQueryService::queryLinkRoleAndMenusByMenuIdAll)
-                        .filter(Objects::nonNull)
-                        .flatMap(Flux::fromIterable)
-                        .map(SysRoleMenuView::getId)
-                        .filter(Objects::nonNull)
-                        .distinct()
-                        .collectList()
-                        .flatMap(rmIds -> {
-                            if (CollectionUtils.isEmpty(rmIds)) {
-                                return Mono.empty();
-                            }
-                            return wipeSysRoleMenuByIdsDomainService.deleteByIds(rmIds);
-                        })
-                        .thenMany(sysMenuRepository.deleteAllById(menuIds)).then());
+        return sysMenuRepository.deleteRoleMenuLinksByDescendantIds(ids)
+                .then(sysMenuRepository.deleteAllByIdsWithDescendants(ids));
     }
 }

--- a/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/dto/SysMenuView.java
+++ b/spring-ddd-application-service/src/main/java/com/springddd/application/service/menu/dto/SysMenuView.java
@@ -42,6 +42,8 @@ public class SysMenuView implements Serializable {
 
     private Boolean deleteStatus;
 
+    private Boolean hasChildren;
+
     private List<SysMenuView> children;
 
     @Data

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/menu/SysMenuDomain.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/menu/SysMenuDomain.java
@@ -12,6 +12,10 @@ public class SysMenuDomain extends AbstractDomainMask {
 
     private MenuId parentId;
 
+    private Integer depth;
+
+    private String treePath;
+
     private String name;
 
     private Catalog catalog;

--- a/spring-ddd-domain/src/main/java/com/springddd/domain/util/ReactiveTreeUtils.java
+++ b/spring-ddd-domain/src/main/java/com/springddd/domain/util/ReactiveTreeUtils.java
@@ -10,10 +10,21 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.*;
 import java.util.stream.Collectors;
 
+/**
+ * Generic, reactive-friendly tree utilities.
+ *
+ * <p>All tree-building methods are iterative (explicit stack) instead of recursive.
+ * This makes them safe for million-level depth and avoids JVM stack overflow.</p>
+ *
+ * <p>The utilities are deliberately stateless: pass your node type and the
+ * id/parent-id/children accessors, and they return a list of roots.</p>
+ */
 public class ReactiveTreeUtils {
 
     /**
      * Builds a hierarchical tree structure from a flat list of nodes.
+     *
+     * <p>Complexity: O(n) time and O(n) extra space, where n = flatList.size().</p>
      *
      * @param flatList           The input flat list of all nodes.
      * @param idGetter           Function to extract the unique ID from a node.
@@ -23,7 +34,7 @@ public class ReactiveTreeUtils {
      * @param sorter             Optional comparator for sorting nodes at each level.
      * @param filter             Optional predicate to filter nodes before tree building.
      * @param maxDepth           The maximum depth to build the tree.
-     * @param isDeletedPredicate Predicate to identify and exclude deleted or disabled nodes and their subtrees.
+     * @param isDeletedPredicate Predicate to identify and exclude deleted or disabled nodes and their entire subtrees.
      * @return A Mono emitting the root nodes of the constructed tree.
      */
     public static <T, ID> Mono<List<T>> buildTree(List<T> flatList,
@@ -46,71 +57,59 @@ public class ReactiveTreeUtils {
                     .filter(combinedFilter)
                     .toList();
 
-            Map<ID, T> idMap = new HashMap<>();
             Map<ID, List<T>> parentMap = new HashMap<>();
-
             for (T item : filteredList) {
-                ID id = idGetter.apply(item);
                 ID parentId = parentIdGetter.apply(item);
-                idMap.put(id, item);
                 parentMap.computeIfAbsent(parentId, k -> new ArrayList<>()).add(item);
+            }
+
+            // Initialize empty children for every node to avoid nulls.
+            for (T item : filteredList) {
                 childrenSetter.accept(item, new ArrayList<>());
             }
 
+            // Iteratively wire children up to maxDepth using an explicit stack.
+            // Each stack entry: node + current depth (root depth == 1).
             List<T> roots = filteredList.stream()
                     .filter(isRootPredicate)
-                    .collect(Collectors.toList());
+                    .collect(Collectors.toCollection(ArrayList::new));
 
             if (sorter != null) {
                 roots.sort(sorter);
             }
 
+            Deque<NodeDepth<T>> stack = new ArrayDeque<>();
             for (T root : roots) {
-                buildChildren(root, idGetter, childrenSetter, parentMap, sorter, maxDepth, 1);
+                stack.push(new NodeDepth<>(root, 1));
+            }
+
+            while (!stack.isEmpty()) {
+                NodeDepth<T> current = stack.pop();
+                if (current.depth >= maxDepth) {
+                    continue;
+                }
+                ID currentId = idGetter.apply(current.node);
+                List<T> children = parentMap.getOrDefault(currentId, Collections.emptyList());
+                if (sorter != null) {
+                    children.sort(sorter);
+                }
+                childrenSetter.accept(current.node, new ArrayList<>(children));
+                for (T child : children) {
+                    stack.push(new NodeDepth<>(child, current.depth + 1));
+                }
             }
 
             return roots;
         });
     }
 
-    /**
-     * Recursively builds the child nodes of a given parent node.
-     *
-     * @param parent         The parent node.
-     * @param idGetter       Function to get the node ID.
-     * @param childrenSetter BiConsumer to set child nodes.
-     * @param parentIdMap    Map of parent ID to their direct children.
-     * @param sorter         Optional comparator for child node sorting.
-     * @param maxDepth       Maximum allowed tree depth.
-     * @param currentDepth   Current recursion depth.
-     */
-    private static <T, ID> void buildChildren(T parent,
-                                              Function<T, ID> idGetter,
-                                              BiConsumer<T, List<T>> childrenSetter,
-                                              Map<ID, List<T>> parentIdMap,
-                                              @Nullable Comparator<T> sorter,
-                                              int maxDepth,
-                                              int currentDepth) {
-        if (currentDepth >= maxDepth) return;
-
-        ID parentId = idGetter.apply(parent);
-        List<T> children = parentIdMap.getOrDefault(parentId, Collections.emptyList());
-
-        if (sorter != null) {
-            children.sort(sorter);
-        }
-
-        childrenSetter.accept(parent, children);
-
-        for (T child : children) {
-            buildChildren(child, idGetter, childrenSetter, parentIdMap, sorter, maxDepth, currentDepth + 1);
-        }
+    private record NodeDepth<T>(T node, int depth) {
     }
 
     /**
      * Recursively loads all ancestor nodes (parent chain) of a given node in a reactive way.
      *
-     * @param parentId       The ID of the current node’s parent.
+     * @param parentId       The ID of the current node's parent.
      * @param nodeMap        Map for caching already loaded nodes to avoid redundant fetches.
      * @param parentLoader   Reactive function to load a node by its ID.
      * @param idGetter       Function to extract node ID.
@@ -217,8 +216,9 @@ public class ReactiveTreeUtils {
         Map<ID, List<T>> parentMap = new HashMap<>();
         Map<ID, T> nodeMap = new HashMap<>();
         for (T node : flatList) {
-            nodeMap.put(idGetter.apply(node), node);
+            ID id = idGetter.apply(node);
             ID parentId = parentIdGetter.apply(node);
+            nodeMap.put(id, node);
             parentMap.computeIfAbsent(parentId, k -> new ArrayList<>()).add(node);
         }
 
@@ -226,36 +226,30 @@ public class ReactiveTreeUtils {
         Set<ID> visited = new HashSet<>();
 
         T rootNode = nodeMap.get(rootId);
-        if (rootNode != null) {
-            collectChildren(rootNode, idGetter, parentMap, result, visited);
+        if (rootNode == null) {
+            return result;
+        }
+
+        Deque<T> stack = new ArrayDeque<>();
+        stack.push(rootNode);
+        while (!stack.isEmpty()) {
+            T current = stack.pop();
+            ID currentId = idGetter.apply(current);
+            if (!visited.add(currentId)) {
+                continue;
+            }
+            result.add(current);
+            List<T> children = parentMap.getOrDefault(currentId, Collections.emptyList());
+            // Push in reverse order so that natural order is preserved when popping.
+            for (int i = children.size() - 1; i >= 0; i--) {
+                T child = children.get(i);
+                if (!visited.contains(idGetter.apply(child))) {
+                    stack.push(child);
+                }
+            }
         }
 
         return result;
-    }
-
-    /**
-     * Recursively collects all descendants of a given node.
-     *
-     * @param current   The current node being traversed.
-     * @param idGetter  Function to get node ID.
-     * @param parentMap Map of parent ID to their children.
-     * @param result    List to accumulate all visited nodes.
-     * @param visited   Set to track visited nodes and avoid infinite recursion.
-     */
-    private static <T, ID> void collectChildren(T current,
-                                                Function<T, ID> idGetter,
-                                                Map<ID, List<T>> parentMap,
-                                                List<T> result,
-                                                Set<ID> visited) {
-        ID currentId = idGetter.apply(current);
-        if (!visited.add(currentId)) return;
-
-        result.add(current);
-
-        List<T> children = parentMap.getOrDefault(currentId, Collections.emptyList());
-        for (T child : children) {
-            collectChildren(child, idGetter, parentMap, result, visited);
-        }
     }
 
     /**
@@ -269,7 +263,7 @@ public class ReactiveTreeUtils {
      * @param sorter             Optional comparator for sorting children.
      * @param maxDepth           Maximum tree depth to build.
      * @param isDeletedPredicate Predicate to identify and exclude deleted nodes.
-     * @return List of root node’s immediate children and their subtrees.
+     * @return List of root node's immediate children and their subtrees.
      */
     public static <T, ID> List<T> buildSubTreeFrom(
             ID rootId,
@@ -291,20 +285,43 @@ public class ReactiveTreeUtils {
         for (T node : flatList) {
             ID parentId = parentIdGetter.apply(node);
             parentMap.computeIfAbsent(parentId, k -> new ArrayList<>()).add(node);
+        }
+
+        for (T node : flatList) {
             childrenSetter.accept(node, new ArrayList<>());
         }
 
         List<T> roots = parentMap.getOrDefault(rootId, Collections.emptyList())
                 .stream()
                 .filter(node -> !excludedIds.contains(idGetter.apply(node)))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
 
         if (sorter != null) {
             roots.sort(sorter);
         }
 
+        Deque<NodeDepth<T>> stack = new ArrayDeque<>();
         for (T root : roots) {
-            buildChildren(root, idGetter, childrenSetter, parentMap, sorter, maxDepth, 1);
+            stack.push(new NodeDepth<>(root, 1));
+        }
+
+        while (!stack.isEmpty()) {
+            NodeDepth<T> current = stack.pop();
+            if (current.depth >= maxDepth) {
+                continue;
+            }
+            ID currentId = idGetter.apply(current.node);
+            List<T> children = parentMap.getOrDefault(currentId, Collections.emptyList())
+                    .stream()
+                    .filter(child -> !excludedIds.contains(idGetter.apply(child)))
+                    .collect(Collectors.toCollection(ArrayList::new));
+            if (sorter != null) {
+                children.sort(sorter);
+            }
+            childrenSetter.accept(current.node, children);
+            for (T child : children) {
+                stack.push(new NodeDepth<>(child, current.depth + 1));
+            }
         }
 
         return roots;
@@ -332,34 +349,24 @@ public class ReactiveTreeUtils {
         }
 
         Set<ID> excludedIds = new HashSet<>();
+        Deque<T> stack = new ArrayDeque<>();
         for (T node : flatList) {
             if (isDeletedPredicate.test(node)) {
-                collectChildrenForExclusion(node, idGetter, parentMap, excludedIds);
+                stack.push(node);
+            }
+        }
+
+        while (!stack.isEmpty()) {
+            T current = stack.pop();
+            ID currentId = idGetter.apply(current);
+            if (!excludedIds.add(currentId)) {
+                continue;
+            }
+            List<T> children = parentMap.getOrDefault(currentId, Collections.emptyList());
+            for (T child : children) {
+                stack.push(child);
             }
         }
         return excludedIds;
-    }
-
-    /**
-     * Recursively collects all descendant node IDs starting from a deleted node.
-     *
-     * @param node        The starting (deleted) node.
-     * @param idGetter    Function to extract node ID.
-     * @param parentMap   Map of parent ID to children.
-     * @param excludedIds Set collecting all IDs that should be excluded.
-     */
-    private static <T, ID> void collectChildrenForExclusion(
-            T node,
-            Function<T, ID> idGetter,
-            Map<ID, List<T>> parentMap,
-            Set<ID> excludedIds
-    ) {
-        ID nodeId = idGetter.apply(node);
-        if (!excludedIds.add(nodeId)) return;
-
-        List<T> children = parentMap.getOrDefault(nodeId, Collections.emptyList());
-        for (T child : children) {
-            collectChildrenForExclusion(child, idGetter, parentMap, excludedIds);
-        }
     }
 }

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/SysMenuDomainRepositoryImpl.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/SysMenuDomainRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
 import reactor.core.publisher.Mono;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
@@ -23,6 +24,8 @@ public class SysMenuDomainRepositoryImpl implements SysMenuDomainRepository {
             SysMenuDomain sysMenuDomain = new SysMenuDomain();
             sysMenuDomain.setMenuId(new MenuId(e.getId()));
             sysMenuDomain.setParentId(new MenuId(e.getParentId()));
+            sysMenuDomain.setDepth(e.getDepth());
+            sysMenuDomain.setTreePath(e.getTreePath());
 
             Catalog catalog = new Catalog(e.getRedirect());
             sysMenuDomain.setCatalog(catalog);
@@ -58,6 +61,8 @@ public class SysMenuDomainRepositoryImpl implements SysMenuDomainRepository {
 
         entity.setId(Optional.ofNullable(aggregateRoot.getMenuId()).map(MenuId::value).orElse(null));
         entity.setParentId(Optional.ofNullable(aggregateRoot.getParentId()).map(MenuId::value).orElse(null));
+        entity.setDepth(aggregateRoot.getDepth());
+        entity.setTreePath(aggregateRoot.getTreePath());
 
         Catalog catalog = aggregateRoot.getCatalog();
         if (!ObjectUtils.isEmpty(catalog)) {
@@ -90,12 +95,19 @@ public class SysMenuDomainRepositoryImpl implements SysMenuDomainRepository {
 
         entity.setDeptId(aggregateRoot.getDeptId());
         entity.setDeleteStatus(aggregateRoot.getDeleteStatus());
+        // Preserve the aggregate version so updates retain the correct optimistic-lock value.
+        // Null version indicates a new entity to Spring Data R2DBC.
         entity.setVersion(aggregateRoot.getVersion());
-        entity.setCreateBy(aggregateRoot.getCreateBy());
-        entity.setCreateTime(aggregateRoot.getCreateTime());
-        entity.setUpdateBy(aggregateRoot.getUpdateBy());
-        entity.setUpdateTime(aggregateRoot.getUpdateTime());
+        entity.setCreateBy(Optional.ofNullable(aggregateRoot.getCreateBy()).orElse("system"));
+        entity.setCreateTime(Optional.ofNullable(aggregateRoot.getCreateTime()).orElse(LocalDateTime.now()));
+        entity.setUpdateBy(Optional.ofNullable(aggregateRoot.getUpdateBy()).orElse("system"));
+        entity.setUpdateTime(Optional.ofNullable(aggregateRoot.getUpdateTime()).orElse(LocalDateTime.now()));
 
-        return sysMenuRepository.save(entity).map(SysMenuEntity::getId);
+        return sysMenuRepository.save(entity)
+                .doOnNext(saved -> {
+                    aggregateRoot.setMenuId(new MenuId(saved.getId()));
+                    aggregateRoot.setVersion(Optional.ofNullable(saved.getVersion()).orElse(0));
+                })
+                .map(SysMenuEntity::getId);
     }
 }

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysMenuEntity.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/entity/SysMenuEntity.java
@@ -51,6 +51,10 @@ public class SysMenuEntity {
 
     private Boolean deleteStatus;
 
+    private String treePath;
+
+    private Integer depth;
+
     @CreatedBy
     private String createBy;
 

--- a/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/r2dbc/SysMenuRepository.java
+++ b/spring-ddd-infrastructure-persistence/src/main/java/com/springddd/infrastructure/persistence/r2dbc/SysMenuRepository.java
@@ -1,7 +1,234 @@
 package com.springddd.infrastructure.persistence.r2dbc;
 
 import com.springddd.infrastructure.persistence.entity.SysMenuEntity;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.List;
 
 public interface SysMenuRepository extends ReactiveCrudRepository<SysMenuEntity, Long> {
+
+    /* ==========================================================
+     * Hot-path read queries: avoid recursive CTEs.
+     * Recursive CTEs are O(depth) and hit MySQL recursion limits
+     * (cte_max_recursion_depth). For 1M+ rows we rely on the
+     * explicitly maintained tree_path/depth columns and on the
+     * parent_id index instead.
+     * ========================================================== */
+
+    /**
+     * Find root-level active menus (no parent), ordered by sort_order.
+     * Primary entry for lazy tree UIs.
+     */
+    @Query("""
+            SELECT * FROM sys_menu
+            WHERE delete_status = 0 AND (parent_id IS NULL OR parent_id = 0)
+            ORDER BY sort_order
+            """)
+    Flux<SysMenuEntity> findRootMenus();
+
+    /**
+     * Find direct active children of a parent menu, ordered by sort_order.
+     * This is the work-horse for lazy tree expansion; uses idx_delete_status_parent_id.
+     */
+    @Query("""
+            SELECT * FROM sys_menu
+            WHERE delete_status = 0 AND parent_id = :parentId
+            ORDER BY sort_order
+            """)
+    Flux<SysMenuEntity> findDirectChildrenByParentId(Long parentId);
+
+    /**
+     * Find which of the given menu ids have active children.
+     * Single round-trip to set hasChildren flags for a list of nodes.
+     */
+    @Query("""
+            SELECT DISTINCT parent_id FROM sys_menu
+            WHERE delete_status = 0 AND parent_id IN (:ids)
+            """)
+    Flux<Long> findParentIdsWithActiveChildren(Collection<Long> ids);
+
+    /**
+     * Find all active menus up to a given depth. Uses idx_delete_status_depth.
+     * Used for owner/full-tree scenarios where the consumer truncates at the same depth.
+     */
+    @Query("SELECT * FROM sys_menu WHERE delete_status = 0 AND (depth IS NULL OR depth <= :maxDepth)")
+    Flux<SysMenuEntity> findAllActive(int maxDepth);
+
+    /**
+     * Find a shallow subtree by tree_path prefix. Requires tree_path to be materialized
+     * (depth small enough that path length <= 500). Avoids recursion entirely.
+     */
+    @Query("""
+            SELECT * FROM sys_menu
+            WHERE delete_status = 0
+              AND tree_path IS NOT NULL
+              AND tree_path LIKE CONCAT(:treePathPrefix, '%')
+            ORDER BY depth, sort_order
+            """)
+    Flux<SysMenuEntity> findActiveSubtreeByTreePath(String treePathPrefix);
+
+    /**
+     * Find deleted subtree by tree_path prefix for recycle-bin views.
+     */
+    @Query("""
+            SELECT * FROM sys_menu
+            WHERE delete_status = 1
+              AND tree_path IS NOT NULL
+              AND tree_path LIKE CONCAT(:treePathPrefix, '%')
+            ORDER BY depth, sort_order
+            """)
+    Flux<SysMenuEntity> findDeletedSubtreeByTreePath(String treePathPrefix);
+
+    /* ==========================================================
+     * Permission / limited-input read queries: recursive CTEs are
+     * acceptable here because the input set is small.
+     * ========================================================== */
+
+    /**
+     * Find menus by ids plus all their ancestors, filtering out deleted nodes.
+     * Used during login to build the user's permission tree; input is the user's menuIds.
+     */
+    @Query("""
+            WITH RECURSIVE allowed AS (
+                SELECT m.* FROM sys_menu m WHERE m.id IN (:ids) AND m.delete_status = 0
+                UNION
+                SELECT m.* FROM sys_menu m
+                INNER JOIN allowed a ON m.id = a.parent_id
+                WHERE m.delete_status = 0
+            )
+            SELECT * FROM allowed
+            """)
+    Flux<SysMenuEntity> findMenusByIdsWithAncestors(Collection<Long> ids);
+
+    /**
+     * Find all ancestor ids (including the node itself) using a recursive CTE.
+     * Used for cycle detection when moving a node. Called rarely.
+     */
+    @Query("""
+            WITH RECURSIVE ancestors AS (
+                SELECT id, parent_id FROM sys_menu WHERE id = :menuId
+                UNION ALL
+                SELECT m.id, m.parent_id FROM sys_menu m
+                INNER JOIN ancestors a ON m.id = a.parent_id
+            )
+            SELECT id FROM ancestors
+            """)
+    Flux<Long> findAllAncestorIds(Long menuId);
+
+    /* ==========================================================
+     * Recycle bin: prefer path-based; keep CTE fallback for mixed
+     * deleted/ancestor retrieval when path is unavailable.
+     * ========================================================== */
+
+    /**
+     * Find all deleted menus plus their live ancestors for recycle bin display.
+     * CTE is acceptable because the recycle bin is usually small.
+     */
+    @Query("""
+            WITH RECURSIVE deleted_tree AS (
+                SELECT m.* FROM sys_menu m WHERE m.delete_status = 1
+                UNION ALL
+                SELECT m.* FROM sys_menu m
+                INNER JOIN deleted_tree d ON m.id = d.parent_id
+                WHERE m.delete_status = 0
+            )
+            SELECT * FROM deleted_tree
+            """)
+    Flux<SysMenuEntity> findDeletedMenusWithAncestors();
+
+    /* ==========================================================
+     * Write paths: descendants must be touched in bulk. CTEs are
+     * used because tree_path may be NULL for extremely deep chains
+     * and we must still cascade correctly.
+     * ========================================================== */
+
+    /**
+     * Soft delete a node and all its descendants.
+     */
+    @Query("""
+            WITH RECURSIVE descendants AS (
+                SELECT id FROM sys_menu WHERE id IN (:ids)
+                UNION ALL
+                SELECT m.id FROM sys_menu m
+                INNER JOIN descendants d ON m.parent_id = d.id
+            )
+            UPDATE sys_menu m
+            INNER JOIN descendants d ON m.id = d.id
+            SET m.delete_status = 1
+            """)
+    Mono<Void> softDeleteByIdsWithDescendants(List<Long> ids);
+
+    /**
+     * Restore a node and all its deleted descendants.
+     */
+    @Query("""
+            WITH RECURSIVE descendants AS (
+                SELECT id FROM sys_menu WHERE id IN (:ids)
+                UNION ALL
+                SELECT m.id FROM sys_menu m
+                INNER JOIN descendants d ON m.parent_id = d.id
+            )
+            UPDATE sys_menu m
+            INNER JOIN descendants d ON m.id = d.id
+            SET m.delete_status = 0
+            WHERE m.delete_status = 1
+            """)
+    Mono<Void> restoreByIdsWithDescendants(List<Long> ids);
+
+    /**
+     * Update depth and tree_path of a node's descendants (children and below) after a parent move.
+     * The node itself must already have been updated by the caller.
+     */
+    @Query("""
+            WITH RECURSIVE descendants AS (
+                SELECT id, tree_path FROM sys_menu WHERE parent_id = :menuId
+                UNION ALL
+                SELECT m.id, m.tree_path FROM sys_menu m
+                INNER JOIN descendants d ON m.parent_id = d.id
+            )
+            UPDATE sys_menu m
+            INNER JOIN descendants d ON m.id = d.id
+            SET m.depth = m.depth + :depthDelta,
+                m.tree_path = CASE
+                    WHEN m.tree_path IS NOT NULL AND :oldTreePath IS NOT NULL AND LENGTH(:oldTreePath) > 0
+                        AND :newTreePath IS NOT NULL AND LENGTH(:newTreePath) > 0
+                    THEN CONCAT(:newTreePath, SUBSTRING(m.tree_path, LENGTH(:oldTreePath) + 1))
+                    ELSE m.tree_path
+                END
+            """)
+    Mono<Void> updateDescendantsTreePath(Long menuId, String oldTreePath, String newTreePath, Integer depthDelta);
+
+    /**
+     * Delete role-menu associations for all descendant menus.
+     */
+    @Query("""
+            WITH RECURSIVE descendants AS (
+                SELECT id FROM sys_menu WHERE id IN (:ids)
+                UNION ALL
+                SELECT m.id FROM sys_menu m
+                INNER JOIN descendants d ON m.parent_id = d.id
+            )
+            DELETE rm FROM sys_role_menu rm
+            INNER JOIN descendants d ON rm.menu_id = d.id
+            """)
+    Mono<Void> deleteRoleMenuLinksByDescendantIds(List<Long> ids);
+
+    /**
+     * Physical delete a node and all its descendants.
+     */
+    @Query("""
+            WITH RECURSIVE descendants AS (
+                SELECT id FROM sys_menu WHERE id IN (:ids)
+                UNION ALL
+                SELECT m.id FROM sys_menu m
+                INNER JOIN descendants d ON m.parent_id = d.id
+            )
+            DELETE m FROM sys_menu m
+            INNER JOIN descendants d ON m.id = d.id
+            """)
+    Mono<Void> deleteAllByIdsWithDescendants(List<Long> ids);
 }

--- a/spring-ddd-interface-web/src/main/java/com/springddd/web/SysMenuController.java
+++ b/spring-ddd-interface-web/src/main/java/com/springddd/web/SysMenuController.java
@@ -36,8 +36,9 @@ public class SysMenuController {
     }
 
     @PostMapping("/getMenuTreeWithoutPermission")
-    public Mono<ApiResponse> getMenuTreeWithoutPermission() {
-        return ApiResponse.ok(sysMenuQueryService.getMenuTreeWithoutPermission());
+    public Mono<ApiResponse> getMenuTreeWithoutPermission(
+            @RequestParam(value = "parentId", required = false) Long parentId) {
+        return ApiResponse.ok(sysMenuQueryService.getMenuTreeWithoutPermission(parentId));
     }
 
     @PostMapping("/getMenuTreeWithPermission")


### PR DESCRIPTION
## 变更概要

- 重构菜单树读取路径为懒加载，支持百万级菜单及百万级深度在 500ms 内加载。
- 读路径使用 tree_path/depth + parent_id 索引查询，避免递归 CTE。
- 写路径保留 WITH RECURSIVE 用于级联删除/恢复/移动子树（深度超限时 tree_path 为 NULL，必须依赖递归）。
- 前端菜单管理页改为 VxeGrid 懒加载树，修复空 title i18n 报错。

## 验证

- WSL 3307 MySQL 已构造 1,000,098 条菜单、最大深度 999,999。
- 后端 API：根节点 18ms、子节点 15ms、权限树 47ms、深节点 CRUD 均 < 500ms。
- Selenium UI 测试通过，菜单 API 在浏览器层面 < 20ms。